### PR TITLE
fix: do not truncate raw files

### DIFF
--- a/internal/git/output_parser.go
+++ b/internal/git/output_parser.go
@@ -46,7 +46,7 @@ func truncateCommandOutput(out io.Reader, maxBytes int64) (string, bool, error) 
 	if err != nil {
 		return "", false, err
 	}
-	truncated := len(buf) >= int(maxBytes)
+	truncated := maxBytes > 0 && len(buf) >= int(maxBytes)
 	// Remove the last line if it's truncated
 	if truncated {
 		// Find the index of the last newline character


### PR DESCRIPTION
The `maxBytes` passed is always `-1` when viewing a raw file, the only call made where `truncate` is `false`.

https://github.com/thomiceli/opengist/blob/864880b4421efe93930ef986780ba9679507ab23/internal/git/commands.go#L82-L85

Which makes the length of the bytes always greater than `maxBytes` and always truncates the last line:

https://github.com/thomiceli/opengist/blob/864880b4421efe93930ef986780ba9679507ab23/internal/git/output_parser.go#L49-L51

This is only an issue for raw files. Using the demo site, you can easily reproduce this issue:

https://opengist.thomice.li/jondoe/e3b6c3bb16244334bf5fb71826c25605 will show the full file
https://opengist.thomice.li/jondoe/e3b6c3bb16244334bf5fb71826c25605/raw/HEAD/a.go will not include the last line