### PR TITLE
Respect ExternalUrl for OAuth

### DIFF
--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -231,7 +231,13 @@ func oauth(ctx echo.Context) error {
 	}
 
 	giteaUrl := trimGiteaUrl()
-	httpDomain := httpProtocol + "://" + ctx.Request().Host
+
+	var opengistUrl string
+	if config.C.ExternalUrl != "" {
+		opengistUrl = config.C.ExternalUrl
+	} else {
+		opengistUrl = httpProtocol + "://" + ctx.Request().Host
+	}
 
 	switch provider {
 	case "github":
@@ -239,7 +245,7 @@ func oauth(ctx echo.Context) error {
 			github.New(
 				config.C.GithubClientKey,
 				config.C.GithubSecret,
-				httpDomain+"/oauth/github/callback"),
+				opengistUrl+"/oauth/github/callback"),
 		)
 
 	case "gitea":
@@ -247,7 +253,7 @@ func oauth(ctx echo.Context) error {
 			gitea.NewCustomisedURL(
 				config.C.GiteaClientKey,
 				config.C.GiteaSecret,
-				httpDomain+"/oauth/gitea/callback",
+				opengistUrl+"/oauth/gitea/callback",
 				giteaUrl+"/login/oauth/authorize",
 				giteaUrl+"/login/oauth/access_token",
 				giteaUrl+"/api/v1/user"),


### PR DESCRIPTION
I may be missing something, but is there a reason not to enforce the configured ExternalUrl for OAuth?

I had issues with the Host being `127:0:0:1:<service-port>` behind nginx reverse proxy unless I overwrite the Host header (as mentioned in the README) but that feels less safe.

(This is untested.)