### PR TITLE
Mardown syntax highlighting + fix escaping in Markdown code

### DIFF
--- a/public/main.ts
+++ b/public/main.ts
@@ -1,7 +1,7 @@
+import 'highlight.js/styles/tokyo-night-dark.css';
 import './style.css';
 import './markdown.css';
 import './favicon.svg';
-import 'highlight.js/styles/tokyo-night-dark.css';
 import moment from 'moment';
 import md from 'markdown-it';
 import hljs from 'highlight.js';
@@ -31,7 +31,22 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     document.querySelectorAll('.markdown').forEach((e: HTMLElement) => {
-        e.innerHTML = md().render(e.innerHTML);
+        e.innerHTML = md({
+            html: true,
+            highlight: function (str, lang) {
+                if (lang && hljs.getLanguage(lang)) {
+                    try {
+                        console.log(str)
+                        console.log(hljs.highlight(str, {language: lang, ignoreIllegals: false}, false));
+                        return '<pre class="hljs"><code>' +
+                            hljs.highlight(str, { language: lang, ignoreIllegals: true }).value +
+                            '</code></pre>';
+                    } catch (__) {}
+                }
+
+                return '<pre class="hljs"><code>' + md().utils.escapeHtml(str) + '</code></pre>';
+            }
+        }).render(e.textContent);
     });
 
     document.querySelectorAll<HTMLElement>('.table-code').forEach((el) => {

--- a/public/style.css
+++ b/public/style.css
@@ -99,8 +99,8 @@ pre {
     max-height: 337px;
 }
 
-.hljs {
-    background: none !important;
+.hljs{
+    color: #c9d1d9;
 }
 
 .line-code.selected {


### PR DESCRIPTION
Closes #27 

* Add syntax highlighting in Markdown code block
* Render html entities

![Screenshot 2023-05-07 at 11-38-51 gist 94fa814ee9bb463384fc7974ff1ac82e - Opengist](https://user-images.githubusercontent.com/27960254/236672119-85710d84-8e2b-4b9b-8d1d-30973a0a4b23.png)

