### PR TITLE
fix: gitea config url for avatar

### DIFF
--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -207,7 +207,7 @@ func oauthCallback(ctx echo.Context) error {
 		case "github":
 			resp, err = http.Get("https://github.com/" + user.NickName + ".keys")
 		case "gitea":
-			resp, err = http.Get(trimGiteaUrl() + "/" + user.NickName + ".keys")
+			resp, err = http.Get(urlJoin(config.C.GiteaUrl, user.NickName+".keys"))
 		}
 
 		if err == nil {
@@ -327,16 +327,6 @@ func logout(ctx echo.Context) error {
 	return redirect(ctx, "/all")
 }
 
-func trimGiteaUrl() string {
-	giteaUrl := config.C.GiteaUrl
-	// remove trailing slash
-	if giteaUrl[len(giteaUrl)-1] == '/' {
-		giteaUrl = giteaUrl[:len(giteaUrl)-1]
-	}
-
-	return giteaUrl
-}
-
 func urlJoin(base string, elem ...string) string {
 	joined, err := url.JoinPath(base, elem...)
 	if err != nil {
@@ -352,7 +342,7 @@ func getAvatarUrlFromProvider(provider string, identifier string) string {
 	case "github":
 		return "https://avatars.githubusercontent.com/u/" + identifier + "?v=4"
 	case "gitea":
-		resp, err := http.Get(trimGiteaUrl() + "/api/v1/users/" + identifier)
+		resp, err := http.Get(urlJoin(config.C.GiteaUrl, "/api/v1/users/", identifier))
 		if err != nil {
 			log.Error().Err(err).Msg("Cannot get user from Gitea")
 			return ""

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -351,7 +351,7 @@ func getAvatarUrlFromProvider(provider string, identifier string) string {
 	case "github":
 		return "https://avatars.githubusercontent.com/u/" + identifier + "?v=4"
 	case "gitea":
-		resp, err := http.Get("https://gitea.com/api/v1/users/" + identifier)
+		resp, err := http.Get(trimGiteaUrl() + "/api/v1/users/" + identifier)
 		if err != nil {
 			log.Error().Err(err).Msg("Cannot get user from Gitea")
 			return ""

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -6,6 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
 	"github.com/labstack/echo/v4"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/gothic"
@@ -17,10 +22,6 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 	"gorm.io/gorm"
-	"io"
-	"net/http"
-	"net/url"
-	"strings"
 )
 
 var title = cases.Title(language.English)
@@ -46,7 +47,7 @@ func processRegister(ctx echo.Context) error {
 
 	sess := getSession(ctx)
 
-	var dto = new(models.UserDTO)
+	dto := new(models.UserDTO)
 	if err := ctx.Bind(dto); err != nil {
 		return errorRes(400, "Cannot bind data", err)
 	}


### PR DESCRIPTION
Rather than getting avatar URL from gitea.com, use the API for the specified Gitea instance in the config.

The second commit is `gofumpt`, let me know if you'd like me to remove it as it's just formatting and unrelated to this PR, it just runs on save on my machine so I left it included as a separate commit.

Non-formatting change is simply https://github.com/thomiceli/opengist/commit/a111a1295544426e4b5f6d3574932dffde739376