### PR TITLE
Fixes unable to access '/root/.config/git/attributes': Permission denied

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,6 +8,4 @@ usermod -o -u "$UID" $USER
 
 chown -R "$USER:$USER" /opengist
 
-export OG_OPENGIST_HOME=/opengist
-
-su -m $USER -c "/app/opengist/opengist"
+exec su $USER -c "OG_OPENGIST_HOME=/opengist /app/opengist/opengist"


### PR DESCRIPTION
Fixes warning message 
```
$ git clone https://opengist.thomice.li/thomas/d8f84d3f0f9d4cf68fec5d2de15ba4d7.git
Cloning into 'd8f84d3f0f9d4cf68fec5d2de15ba4d7'...
remote: warning: unable to access '/root/.config/git/attributes': Permission denied
```
