### PR TITLE
Trivial Typo: Change 'Gitlab' to 'GitLab'

### DIFF
--- a/docs/administration/oauth-providers.md
+++ b/docs/administration/oauth-providers.md
@@ -21,7 +21,7 @@ Opengist can be configured to use OAuth to authenticate users, with GitHub, Gite
   ```yaml
   gitlab.client-key: <key>
   gitlab.secret: <secret>
-  # URL of the Gitlab instance. Default: https://gitlab.com/
+  # URL of the GitLab instance. Default: https://gitlab.com/
   gitlab.url: https://gitlab.com/
   ```
 

--- a/internal/i18n/locales/en-US.yml
+++ b/internal/i18n/locales/en-US.yml
@@ -92,10 +92,10 @@ settings.email-help: Used for commits and Gravatar
 settings.email-set: Set email
 settings.link-accounts: Link accounts
 settings.link-github-account: Link GitHub account
-settings.link-gitlab-account: Link Gitlab account
+settings.link-gitlab-account: Link GitLab account
 settings.link-gitea-account: Link Gitea account
 settings.unlink-github-account: Unlink GitHub account
-settings.unlink-gitlab-account: Unlink Gitlab account
+settings.unlink-gitlab-account: Unlink GitLab account
 settings.unlink-gitea-account: Unlink Gitea account
 settings.delete-account: Delete account
 settings.delete-account-confirm: Are you sure you want to delete your account ?
@@ -123,7 +123,7 @@ auth.password: Password
 auth.register-instead: Register instead
 auth.login-instead: Login instead
 auth.github-oauth: Continue with GitHub account
-auth.gitlab-oauth: Continue with Gitlab account
+auth.gitlab-oauth: Continue with GitLab account
 auth.gitea-oauth: Continue with Gitea account
 
 error: Error

--- a/internal/i18n/locales/zh-TW.yml
+++ b/internal/i18n/locales/zh-TW.yml
@@ -92,8 +92,10 @@ settings.email-help: 用於提交和 Gravatar
 settings.email-set: 設定電子郵件
 settings.link-accounts: 連結帳號
 settings.link-github-account: 連結 GitHub 帳號
+settings.link-gitlab-account: 連結 Gitlab 帳號
 settings.link-gitea-account: 連結 Gitea 帳號
 settings.unlink-github-account: 取消連結 GitHub 帳號
+settings.unlink-gitlab-account: 取消連結 GitLab 帳號
 settings.unlink-gitea-account: 取消連結 Gitea 帳號
 settings.delete-account: 刪除帳號
 settings.delete-account-confirm: 確定要刪除您的帳號嗎？
@@ -121,6 +123,7 @@ auth.password: 密碼
 auth.register-instead: 註冊
 auth.login-instead: 登錄
 auth.github-oauth: 用 GitHub 帳號繼續
+auth.gitlab-oauth: 用 GitLab 帳號繼續
 auth.gitea-oauth: 用 Gitea 帳號繼續
 
 error: 錯誤

--- a/templates/pages/settings.html
+++ b/templates/pages/settings.html
@@ -51,7 +51,7 @@
                                 {{ if .gitlabOauth }}
                                     {{ if .userLogged.GitlabID }}
                                         <a href="{{ $.c.ExternalUrl }}/oauth/gitlab" class="block w-full mb-2 text-center whitespace-nowrap text-slate-700 dark:text-slate-300{{ if .syncReposFromFS }} text-slate-500 cursor-not-allowed {{ end }}rounded border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 px-2.5 py-2 text-xs font-medium text-gray-700 dark:text-white shadow-sm hover:bg-gray-100 dark:hover:bg-gray-700 hover:border-gray-500 hover:text-slate-700 dark:hover:text-slate-300 focus:outline-none focus:ring-1 focus:border-primary-500 focus:ring-primary-500 leading-3"
-                                           onclick="return confirm('Are you sure you want to unlink your Gitlab account? You may lose access to Opengist if it\'s your only way to log in.')">
+                                           onclick="return confirm('Are you sure you want to unlink your GitLab account? You may lose access to Opengist if it\'s your only way to log in.')">
                                             {{ .locale.Tr "settings.unlink-gitlab-account" }}
                                         </a>
                                     {{ else }}


### PR DESCRIPTION

## Description:
The word "Gitlab" is spelled incorrectly in following locations, including a locale file, web setting page, and markdown file.

## Additional Note:
Feel free to drop any commits if you find further improvements or corrections 😄 