### PR TITLE
fix auth page error

### DIFF
--- a/templates/pages/auth_form.html
+++ b/templates/pages/auth_form.html
@@ -68,7 +68,7 @@
                             {{ end }}
                             {{ if .gitlabOauth }}
                                 <a href="{{ $.c.ExternalUrl }}/oauth/gitlab" class="block w-full mb-2 text-center whitespace-nowrap text-slate-700 dark:text-slate-300{{ if .syncReposFromFS }} text-slate-500 cursor-not-allowed {{ end }}rounded border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 px-2.5 py-2 text-xs font-medium text-gray-700 dark:text-white shadow-sm hover:bg-gray-100 dark:hover:bg-gray-700 hover:border-gray-500 hover:text-slate-700 dark:hover:text-slate-300 focus:outline-none focus:ring-1 focus:border-primary-500 focus:ring-primary-500 leading-3">
-                                    {{ .locale.Tr "auth.oauth" .c.GitLabName}}
+                                    {{ .locale.Tr "auth.oauth" .c.GitlabName}}
                                 </a>
                             {{ end }}
                             {{ if .giteaOauth }}


### PR DESCRIPTION
`FTL error="template: auth_form.html:71:65: executing \"auth_form.html\" at <.c.GitLabName>: can't evaluate field GitLabName in type interface {}"`