### PR TITLE
feat: make edit visibility a toggle

### DIFF
--- a/internal/db/gist.go
+++ b/internal/db/gist.go
@@ -2,15 +2,16 @@ package db
 
 import (
 	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/lexers"
 	"github.com/dustin/go-humanize"
 	"github.com/rs/zerolog/log"
 	"github.com/thomiceli/opengist/internal/index"
-	"os/exec"
-	"path/filepath"
-	"strings"
-	"time"
 
 	"github.com/thomiceli/opengist/internal/git"
 	"gorm.io/gorm"
@@ -525,13 +526,17 @@ func (gist *Gist) GetLanguagesFromFiles() ([]string, error) {
 // -- DTO -- //
 
 type GistDTO struct {
-	Title       string     `validate:"max=250" form:"title"`
-	Description string     `validate:"max=1000" form:"description"`
-	URL         string     `validate:"max=32,alphanumdashorempty" form:"url"`
-	Private     Visibility `validate:"number,min=0,max=2" form:"private"`
-	Files       []FileDTO  `validate:"min=1,dive"`
-	Name        []string   `form:"name"`
-	Content     []string   `form:"content"`
+	Title       string    `validate:"max=250" form:"title"`
+	Description string    `validate:"max=1000" form:"description"`
+	URL         string    `validate:"max=32,alphanumdashorempty" form:"url"`
+	Files       []FileDTO `validate:"min=1,dive"`
+	Name        []string  `form:"name"`
+	Content     []string  `form:"content"`
+	VisibilityDTO
+}
+
+type VisibilityDTO struct {
+	Private Visibility `validate:"number,min=0,max=2" form:"private"`
 }
 
 type FileDTO struct {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -5,9 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/thomiceli/opengist/internal/index"
-	"github.com/thomiceli/opengist/internal/utils"
-	"github.com/thomiceli/opengist/templates"
 	htmlpkg "html"
 	"html/template"
 	"io"
@@ -20,6 +17,10 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/thomiceli/opengist/internal/index"
+	"github.com/thomiceli/opengist/internal/utils"
+	"github.com/thomiceli/opengist/templates"
 
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo/v4"
@@ -313,7 +314,7 @@ func NewServer(isDev bool) *Server {
 			g3.GET("/rev/:revision", gistIndex)
 			g3.GET("/revisions", revisions)
 			g3.GET("/archive/:revision", downloadZip)
-			g3.POST("/visibility", toggleVisibility, logged, writePermission)
+			g3.POST("/visibility", editVisibility, logged, writePermission)
 			g3.POST("/delete", deleteGist, logged, writePermission)
 			g3.GET("/raw/:revision/:file", rawFile)
 			g3.GET("/download/:revision/:file", downloadFile)

--- a/internal/web/test/gist_test.go
+++ b/internal/web/test/gist_test.go
@@ -1,10 +1,11 @@
 package test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	"github.com/thomiceli/opengist/internal/db"
 	"github.com/thomiceli/opengist/internal/git"
-	"testing"
 )
 
 func TestGists(t *testing.T) {
@@ -28,9 +29,11 @@ func TestGists(t *testing.T) {
 	gist1 := db.GistDTO{
 		Title:       "gist1",
 		Description: "my first gist",
-		Private:     0,
-		Name:        []string{"gist1.txt", "gist2.txt", "gist3.txt"},
-		Content:     []string{"yeah", "yeah\ncool", "yeah\ncool gist actually"},
+		VisibilityDTO: db.VisibilityDTO{
+			Private: 0,
+		},
+		Name:    []string{"gist1.txt", "gist2.txt", "gist3.txt"},
+		Content: []string{"yeah", "yeah\ncool", "yeah\ncool gist actually"},
 	}
 	err = s.request("POST", "/", gist1, 302)
 	require.NoError(t, err)
@@ -57,9 +60,11 @@ func TestGists(t *testing.T) {
 	gist2 := db.GistDTO{
 		Title:       "gist2",
 		Description: "my second gist",
-		Private:     0,
-		Name:        []string{"", "gist2.txt", "gist3.txt"},
-		Content:     []string{"", "yeah\ncool", "yeah\ncool gist actually"},
+		VisibilityDTO: db.VisibilityDTO{
+			Private: 0,
+		},
+		Name:    []string{"", "gist2.txt", "gist3.txt"},
+		Content: []string{"", "yeah\ncool", "yeah\ncool gist actually"},
 	}
 	err = s.request("POST", "/", gist2, 200)
 	require.NoError(t, err)
@@ -67,9 +72,11 @@ func TestGists(t *testing.T) {
 	gist3 := db.GistDTO{
 		Title:       "gist3",
 		Description: "my third gist",
-		Private:     0,
-		Name:        []string{""},
-		Content:     []string{"yeah"},
+		VisibilityDTO: db.VisibilityDTO{
+			Private: 0,
+		},
+		Name:    []string{""},
+		Content: []string{"yeah"},
 	}
 	err = s.request("POST", "/", gist3, 302)
 	require.NoError(t, err)
@@ -110,9 +117,11 @@ func TestVisibility(t *testing.T) {
 	gist1 := db.GistDTO{
 		Title:       "gist1",
 		Description: "my first gist",
-		Private:     db.UnlistedVisibility,
-		Name:        []string{""},
-		Content:     []string{"yeah"},
+		VisibilityDTO: db.VisibilityDTO{
+			Private: db.UnlistedVisibility,
+		},
+		Name:    []string{""},
+		Content: []string{"yeah"},
 	}
 	err = s.request("POST", "/", gist1, 302)
 	require.NoError(t, err)
@@ -121,19 +130,19 @@ func TestVisibility(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, db.UnlistedVisibility, gist1db.Private)
 
-	err = s.request("POST", "/"+gist1db.User.Username+"/"+gist1db.Uuid+"/visibility", nil, 302)
+	err = s.request("POST", "/"+gist1db.User.Username+"/"+gist1db.Uuid+"/visibility", db.VisibilityDTO{Private: db.PrivateVisibility}, 302)
 	require.NoError(t, err)
 	gist1db, err = db.GetGistByID("1")
 	require.NoError(t, err)
 	require.Equal(t, db.PrivateVisibility, gist1db.Private)
 
-	err = s.request("POST", "/"+gist1db.User.Username+"/"+gist1db.Uuid+"/visibility", nil, 302)
+	err = s.request("POST", "/"+gist1db.User.Username+"/"+gist1db.Uuid+"/visibility", db.VisibilityDTO{Private: db.PublicVisibility}, 302)
 	require.NoError(t, err)
 	gist1db, err = db.GetGistByID("1")
 	require.NoError(t, err)
 	require.Equal(t, db.PublicVisibility, gist1db.Private)
 
-	err = s.request("POST", "/"+gist1db.User.Username+"/"+gist1db.Uuid+"/visibility", nil, 302)
+	err = s.request("POST", "/"+gist1db.User.Username+"/"+gist1db.Uuid+"/visibility", db.VisibilityDTO{Private: db.UnlistedVisibility}, 302)
 	require.NoError(t, err)
 	gist1db, err = db.GetGistByID("1")
 	require.NoError(t, err)
@@ -152,9 +161,11 @@ func TestLikeFork(t *testing.T) {
 	gist1 := db.GistDTO{
 		Title:       "gist1",
 		Description: "my first gist",
-		Private:     1,
-		Name:        []string{""},
-		Content:     []string{"yeah"},
+		VisibilityDTO: db.VisibilityDTO{
+			Private: 1,
+		},
+		Name:    []string{""},
+		Content: []string{"yeah"},
 	}
 	err = s.request("POST", "/", gist1, 302)
 	require.NoError(t, err)
@@ -212,9 +223,11 @@ func TestCustomUrl(t *testing.T) {
 		Title:       "gist1",
 		URL:         "my-gist",
 		Description: "my first gist",
-		Private:     0,
-		Name:        []string{"gist1.txt", "gist2.txt", "gist3.txt"},
-		Content:     []string{"yeah", "yeah\ncool", "yeah\ncool gist actually"},
+		VisibilityDTO: db.VisibilityDTO{
+			Private: 0,
+		},
+		Name:    []string{"gist1.txt", "gist2.txt", "gist3.txt"},
+		Content: []string{"yeah", "yeah\ncool", "yeah\ncool gist actually"},
 	}
 	err = s.request("POST", "/", gist1, 302)
 	require.NoError(t, err)
@@ -241,9 +254,11 @@ func TestCustomUrl(t *testing.T) {
 	gist2 := db.GistDTO{
 		Title:       "gist2",
 		Description: "my second gist",
-		Private:     0,
-		Name:        []string{"gist1.txt", "gist2.txt", "gist3.txt"},
-		Content:     []string{"yeah", "yeah\ncool", "yeah\ncool gist actually"},
+		VisibilityDTO: db.VisibilityDTO{
+			Private: 0,
+		},
+		Name:    []string{"gist1.txt", "gist2.txt", "gist3.txt"},
+		Content: []string{"yeah", "yeah\ncool", "yeah\ncool gist actually"},
 	}
 	err = s.request("POST", "/", gist2, 302)
 	require.NoError(t, err)

--- a/templates/pages/edit.html
+++ b/templates/pages/edit.html
@@ -10,19 +10,23 @@
             <div class="lg:flex-row flex py-2 lg:py-0 lg:ml-auto">
                 <form id="visibility" class="flex items-center whitespace-nowrap" method="post" action="{{ $.c.ExternalUrl }}/{{ .gist.User.Username }}/{{ .gist.Identifier }}/visibility">
                     {{ .csrfHtml }}
-                    <button type="submit" class="ml-auto relative inline-flex items-center space-x-2 rounded-md border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 px-2 py-1.5 text-xs font-medium text-slate-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:border-gray-500 hover:text-slate-700 dark:hover:text-slate-300 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 leading-3">
-                        {{ if eq .gist.Private 2 }}
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                            </svg>
-                        {{ else }}
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
-                            </svg>
-                        {{ end }}
-                        {{ .locale.Tr "gist.edit.change-visibility" }} {{ visibilityStr .gist.Private.Next true }}
-                    </button>
+                    <div class="ml-auto inline-flex ">
+                        <button id="submit-gist" type="submit" name="private" value="0" class="ml-auto relative inline-flex items-center space-x-2 rounded-l-md border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 px-2 py-1.5 text-xs font-medium text-slate-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:border-gray-500 hover:text-slate-700 dark:hover:text-slate-300 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 leading-3">{{ .locale.Tr "gist.edit.change-visibility" }} {{ .locale.Tr "gist.public" }}</button>
+                        <div class="relative -ml-px block">
+                            <button type="button" class="ml-auto relative inline-flex items-center space-x-2 rounded-r-md border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 px-2 py-1.5 text-xs font-medium text-slate-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:border-gray-500 hover:text-slate-700 dark:hover:text-slate-300 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 leading-3" id="gist-visibility-menu-button">
+                                <svg class="h-5 w-5" viewBox="0 0 20 20" fill="white" aria-hidden="true">
+                                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                                </svg>
+                            </button>
+                            <div id="gist-menu-visibility" class="hidden absolute right-0 z-10 mt-2 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="gist-visibility-menu-button">
+                                <div class="rounded-md dark:bg-gray-800 bg-white shadow-lg ring-1 ring-gray-50 dark:ring-gray-700 focus:outline-none" role="none" style="word-break: keep-all">
+                                    <span class="text-gray-700 block px-4 py-2 text-sm cursor-pointer dark:text-slate-300 hover:text-slate-500 dark:hover:text-slate-400 gist-visibility-option" data-btntext="{{ .locale.Tr "gist.edit.change-visibility" }} {{ .locale.Tr "gist.public" }}" data-visibility="0" role="menuitem">{{ .locale.Tr "gist.public" }}</span>
+                                    <span class="text-gray-700 block px-4 py-2 text-sm cursor-pointer dark:text-slate-300 hover:text-slate-500 dark:hover:text-slate-400 gist-visibility-option" data-btntext="{{ .locale.Tr "gist.edit.change-visibility" }} {{ .locale.Tr "gist.unlisted" }}" data-visibility="1" role="menuitem">{{ .locale.Tr "gist.unlisted" }}</span>
+                                    <span class="text-gray-700 block px-4 py-2 text-sm cursor-pointer dark:text-slate-300 hover:text-slate-500 dark:hover:text-slate-400 gist-visibility-option" data-btntext="{{ .locale.Tr "gist.edit.change-visibility" }} {{ .locale.Tr "gist.private" }}" data-visibility="2" role="menuitem">{{ .locale.Tr "gist.private" }}</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </form>
                 <form id="delete" onsubmit="return confirm('Are you sure you want to delete this gist ?')" class="ml-2 flex items-center" method="post" action="{{ $.c.ExternalUrl }}/{{ .gist.User.Username }}/{{ .gist.Identifier }}/delete">
                     {{ .csrfHtml }}

--- a/templates/pages/edit.html
+++ b/templates/pages/edit.html
@@ -14,7 +14,7 @@
                         <button id="submit-gist" type="submit" name="private" value="0" class="ml-auto relative inline-flex items-center space-x-2 rounded-l-md border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 px-2 py-1.5 text-xs font-medium text-slate-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:border-gray-500 hover:text-slate-700 dark:hover:text-slate-300 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 leading-3">{{ .locale.Tr "gist.edit.change-visibility" }} {{ .locale.Tr "gist.public" }}</button>
                         <div class="relative -ml-px block">
                             <button type="button" class="ml-auto relative inline-flex items-center space-x-2 rounded-r-md border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 px-2 py-1.5 text-xs font-medium text-slate-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:border-gray-500 hover:text-slate-700 dark:hover:text-slate-300 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 leading-3" id="gist-visibility-menu-button">
-                                <svg class="h-5 w-5" viewBox="0 0 20 20" fill="white" aria-hidden="true">
+                                <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                                     <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
                                 </svg>
                             </button>


### PR DESCRIPTION
Resolves #153 

(Sorry for the formatting noise, let me know if you want me to pick out only my changes, I forgot to turn off `gofumpt` prior to editing)

This leverages the existing JS for the visibility toggle button on the create page, which may or may not be desirable.

Feel free to use or discard this PR (or have me make changes) if you want to go another direction, whichever is easiest for you. :slightly_smiling_face: 

![opengist-visibility-edit](https://github.com/thomiceli/opengist/assets/42128690/becd9fb5-1c8e-4ff8-aec3-c2191392ab92)
