### PR TITLE
Fix size in URL

### DIFF
--- a/internal/db/gist.go
+++ b/internal/db/gist.go
@@ -540,7 +540,7 @@ func (gist *Gist) GetLanguagesFromFiles() ([]string, error) {
 type GistDTO struct {
 	Title       string    `validate:"max=250" form:"title"`
 	Description string    `validate:"max=1000" form:"description"`
-	URL         string    `validate:"max=32,alphanumdashorempty" form:"url"`
+	URL         string    `validate:"max=2048,alphanumdashorempty" form:"url"`
 	Files       []FileDTO `validate:"min=1,dive"`
 	Name        []string  `form:"name"`
 	Content     []string  `form:"content"`

--- a/internal/hooks/post_receive.go
+++ b/internal/hooks/post_receive.go
@@ -50,7 +50,7 @@ func PostReceive(in io.Reader, out, er io.Writer) error {
 		outputSb.WriteString(fmt.Sprintf("Gist visibility set to %s\n\n", opts["visibility"]))
 	}
 
-	if opts["url"] != "" && validator.Var(opts["url"], "max=32,alphanumdashorempty") == nil {
+	if opts["url"] != "" && validator.Var(opts["url"], "max=2048,alphanumdashorempty") == nil {
 		gist.URL = opts["url"]
 		lastIndex := strings.LastIndex(gistUrl, "/")
 		gistUrl = gistUrl[:lastIndex+1] + gist.URL


### PR DESCRIPTION
fix #330

```txt
Browser     Address bar   document.location
                          or anchor tag
------------------------------------------
Chrome          32779           >64k
Android          8192           >64k
Firefox          >64k           >64k
Safari           >64k           >64k
IE11             2047           5120
Edge 16          2047          10240
```
[ref](https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers#417184)

I'm not sure if is necessary a migration for this.