### PR TITLE
Allow adding multiple empty lines in editor.

### DIFF
--- a/public/editor.ts
+++ b/public/editor.ts
@@ -1,6 +1,6 @@
 import {EditorView, gutter, keymap, lineNumbers} from "@codemirror/view";
 import {Compartment, EditorState, Facet, Line, SelectionRange} from "@codemirror/state";
-import {indentLess} from "@codemirror/commands";
+import {defaultKeymap, indentLess} from "@codemirror/commands";
 
 document.addEventListener("DOMContentLoaded", () => {
     EditorView.theme({}, {dark: true});
@@ -27,7 +27,10 @@ document.addEventListener("DOMContentLoaded", () => {
             extensions: [
                 lineNumbers(),
                 gutter({class: "cm-mygutter"}),
-                keymap.of([{key: "Tab", run: customIndentMore, shift: indentLess}]),
+                keymap.of([
+                    {key: "Tab", run: customIndentMore, shift: indentLess},
+                    ...defaultKeymap,
+                ]),
                 indentSize.of(EditorState.tabSize.of(2)),
                 wrapMode.of([]),
                 indentType.of(txtFacet.of("space")),


### PR DESCRIPTION
For some reason, adding multiple empty line when editing a snippet won't add new empty lines and will remain on the first created - not sure it is expected, but this is happening on a basic firefox on linux setup.

Adding default keymap to codemirror's configuration is fixing this behavior and allows editing more efficiently code in the online editor.