### PR TITLE
Fix oauth endpoint to support detecting https in 'Forwarded' header

### DIFF
--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -315,6 +315,20 @@ func oauth(ctx echo.Context) error {
 		httpProtocol = "https"
 	}
 
+	forwarded_hdr := ctx.Request().Header.Get("Forwarded")
+	if forwarded_hdr != "" {
+		fields := strings.Split(forwarded_hdr, ";")
+		fwd := make(map[string]string)
+		for _, v := range fields {
+			p := strings.Split(v, "=")
+			fwd[p[0]] = p[1]
+		}
+		val, ok := fwd["proto"]
+		if ok && val == "https" {
+			httpProtocol = "https"
+		}
+	}
+
 	var opengistUrl string
 	if config.C.ExternalUrl != "" {
 		opengistUrl = config.C.ExternalUrl


### PR DESCRIPTION
This fix enables google openid oauth2 mechanism, the current code couldn't detect that it should redirect to https.

In a perfect world, this check plus the existing one for X-Forwarded-Proto should be incorporated into https://github.com/labstack/echo/blob/master/context.go#L275

Documentation on the header support that this fix implements: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded