### PR TITLE
Respect file scheme URIs for SQLite.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -17,8 +17,8 @@ opengist-home:
 # Secret key used for session store & encrypt MFA data on database. Default: <randomized 32 bytes>
 secret-key:
 
-# URI of the database. Default: opengist.db (SQLite)
-# SQLite:        file name
+# URI of the database. Default: opengist.db (SQLite) is placed in opengist-home
+# SQLite:        file:/path/to/database
 # PostgreSQL:    postgres://user:password@host:port/database
 # MySQL/MariaDB: mysql://user:password@host:port/database
 db-uri: opengist.db

--- a/docs/configuration/databases/sqlite.md
+++ b/docs/configuration/databases/sqlite.md
@@ -5,7 +5,7 @@ By default, Opengist uses SQLite as the database backend.
 Because SQLite is a file-based database, there is not much configuration to tweak.
 
 The configuration `db-uri`/`OG_DB_URI` refers to the path of the SQLite database file relative in the `$opengist-home/` directory (default `opengist.db`),
-although it can be left untouched.
+although it can be left untouched. You can also use an absolute path outside the `$opengist-home/` directory.
 
 The SQLite journal mode is set to [`WAL` (Write-Ahead Logging)](https://www.sqlite.org/pragma.html#pragma_journal_mode) by default and can be changed.
 

--- a/docs/configuration/databases/sqlite.md
+++ b/docs/configuration/databases/sqlite.md
@@ -14,6 +14,9 @@ The SQLite journal mode is set to [`WAL` (Write-Ahead Logging)](https://www.sqli
 # default
 db-uri: opengist.db
 sqlite.journal-mode: WAL
+
+# absolute path outside the $opengist-home/ directory
+db-uri: file:/home/user/opengist.db
 ```
 
 #### Environment variable


### PR DESCRIPTION
This PR aims to introduce proper `file:` Scheme URI parsing for SQLite DB option.

The changes are done based on the following documentation
- https://www.sqlite.org/uri.html
- https://www.sqlite.org/c3ref/open.html#urifilenamesinsqlite3open

The current behavior where if no scheme (`file:`) is mentioned, i.e. the file name is directly given like (`opengist.db`) the file is created under the `opengist-home` folder. This way the existing behavior is maintained without breaking backward compatibility.

With the new changes, the SQLite DB can be hosted independent of the home folder of Opengist. This also matches the behavior for PostgreSQL and MySQL / MariaDB, where the DB is not necessarily hosted within the Opengist home directory.

The `config.yml` file has been updated to reflect these changes.