### PR TITLE
fixup! esbuild for all other platforms (#393)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -469,9 +469,7 @@
       ],
       "engines": {
         "node": ">=12"
-      },
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w=="
+      }
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.18.20",


### PR DESCRIPTION
Fix package-lock.json

I broke it :( , luckily seems to be only for nix :)

Tested on macos, arch linux, nixos