### PR TITLE
Skip CSRF for embeds

### DIFF
--- a/internal/web/server/middlewares.go
+++ b/internal/web/server/middlewares.go
@@ -58,6 +58,11 @@ func (s *Server) registerMiddlewares() {
 			CookiePath:     "/",
 			CookieHTTPOnly: true,
 			CookieSameSite: http.SameSiteStrictMode,
+			Skipper: func(ctx echo.Context) bool {
+				/* skip CSRF for embeds */
+				gistName := ctx.Param("gistname")
+				return filepath.Ext(gistName) == ".js"
+			},
 		}))
 		s.echo.Use(Middleware(csrfInit).toEcho())
 	}


### PR DESCRIPTION
The CSRF middleware sets a _csrf cookie also for loading the embed javascript on third-party sites. With this change no _csrf cookie is set when loading the embed javascript (regardless if third-party site or first-party).