### PR TITLE
fix: replace path.Join with filepath.Join for file system paths

### DIFF
--- a/internal/web/test/auth_test.go
+++ b/internal/web/test/auth_test.go
@@ -1,14 +1,15 @@
 package test
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 	"github.com/thomiceli/opengist/internal/config"
 	"github.com/thomiceli/opengist/internal/db"
-	"os"
-	"os/exec"
-	"path"
-	"testing"
 )
 
 func TestRegister(t *testing.T) {
@@ -280,26 +281,26 @@ func TestGitOperations(t *testing.T) {
 }
 
 func clientGitClone(creds string, user string, url string) error {
-	return exec.Command("git", "clone", "http://"+creds+"@localhost:6157/"+user+"/"+url, path.Join(config.GetHomeDir(), "tmp", url)).Run()
+	return exec.Command("git", "clone", "http://"+creds+"@localhost:6157/"+user+"/"+url, filepath.Join(config.GetHomeDir(), "tmp", url)).Run()
 }
 
 func clientGitPush(url string) error {
-	f, err := os.Create(path.Join(config.GetHomeDir(), "tmp", url, "newfile.txt"))
+	f, err := os.Create(filepath.Join(config.GetHomeDir(), "tmp", url, "newfile.txt"))
 	if err != nil {
 		return err
 	}
 	f.Close()
 
-	_ = exec.Command("git", "-C", path.Join(config.GetHomeDir(), "tmp", url), "add", "newfile.txt").Run()
-	_ = exec.Command("git", "-C", path.Join(config.GetHomeDir(), "tmp", url), "commit", "-m", "new file").Run()
-	err = exec.Command("git", "-C", path.Join(config.GetHomeDir(), "tmp", url), "push", "origin", "master").Run()
+	_ = exec.Command("git", "-C", filepath.Join(config.GetHomeDir(), "tmp", url), "add", "newfile.txt").Run()
+	_ = exec.Command("git", "-C", filepath.Join(config.GetHomeDir(), "tmp", url), "commit", "-m", "new file").Run()
+	err = exec.Command("git", "-C", filepath.Join(config.GetHomeDir(), "tmp", url), "push", "origin", "master").Run()
 
-	_ = os.RemoveAll(path.Join(config.GetHomeDir(), "tmp", url))
+	_ = os.RemoveAll(filepath.Join(config.GetHomeDir(), "tmp", url))
 
 	return err
 }
 
 func clientCheckRepo(url string, file string) error {
-	_, err := os.ReadFile(path.Join(config.GetHomeDir(), "tmp", url, file))
+	_, err := os.ReadFile(filepath.Join(config.GetHomeDir(), "tmp", url, file))
 	return err
 }

--- a/internal/web/test/server.go
+++ b/internal/web/test/server.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -35,7 +34,7 @@ type TestServer struct {
 
 func newTestServer() (*TestServer, error) {
 	s := &TestServer{
-		server: server.NewServer(true, path.Join(config.GetHomeDir(), "tmp", "sessions"), true),
+		server: server.NewServer(true, filepath.Join(config.GetHomeDir(), "tmp", "sessions"), true),
 	}
 
 	go s.start()
@@ -146,7 +145,7 @@ func Setup(t *testing.T) *TestServer {
 
 	config.SetupSecretKey()
 
-	git.ReposDirectory = path.Join("tests")
+	git.ReposDirectory = filepath.Join("tests")
 
 	config.C.IndexEnabled = false
 	config.C.LogLevel = "error"
@@ -205,7 +204,7 @@ func Teardown(t *testing.T, s *TestServer) {
 	err := db.TruncateDatabase()
 	require.NoError(t, err, "Could not truncate database")
 
-	err = os.RemoveAll(path.Join(config.GetHomeDir(), "tests"))
+	err = os.RemoveAll(filepath.Join(config.GetHomeDir(), "tests"))
 	require.NoError(t, err, "Could not remove repos directory")
 
 	if runtime.GOOS == "windows" {
@@ -214,7 +213,7 @@ func Teardown(t *testing.T, s *TestServer) {
 
 		time.Sleep(2 * time.Second)
 	}
-	err = os.RemoveAll(path.Join(config.GetHomeDir(), "tmp"))
+	err = os.RemoveAll(filepath.Join(config.GetHomeDir(), "tmp"))
 	require.NoError(t, err, "Could not remove tmp directory")
 
 	// err = os.RemoveAll(path.Join(config.C.OpengistHome, "testsindex"))


### PR DESCRIPTION
path.Join is mostly used for urls or unix specific paths and might cause errors on windows. 
filepath.Join is cross platform and more consistent with the code.