### PR TITLE
feat: add MIME type support for raw file serving

### DIFF
--- a/internal/web/handlers/gist/download.go
+++ b/internal/web/handlers/gist/download.go
@@ -3,9 +3,11 @@ package gist
 import (
 	"archive/zip"
 	"bytes"
+	"strconv"
+
 	"github.com/thomiceli/opengist/internal/db"
 	"github.com/thomiceli/opengist/internal/web/context"
-	"strconv"
+	"github.com/thomiceli/opengist/internal/web/handlers"
 )
 
 func RawFile(ctx *context.Context) error {
@@ -18,7 +20,8 @@ func RawFile(ctx *context.Context) error {
 	if file == nil {
 		return ctx.NotFound("File not found")
 	}
-
+	contentType := handlers.GetContentTypeFromFilename(file.Filename)
+	ctx.Response().Header().Set("Content-Type", contentType)
 	return ctx.PlainText(200, file.Content)
 }
 

--- a/internal/web/handlers/util.go
+++ b/internal/web/handlers/util.go
@@ -2,10 +2,12 @@ package handlers
 
 import (
 	"errors"
-	"github.com/thomiceli/opengist/internal/web/context"
 	"html/template"
+	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/thomiceli/opengist/internal/web/context"
 )
 
 func GetPage(ctx *context.Context) int {
@@ -76,4 +78,14 @@ func ParseSearchQueryStr(query string) (string, map[string]string) {
 
 	content := strings.TrimSpace(contentBuilder.String())
 	return content, metadata
+}
+
+func GetContentTypeFromFilename(filename string) string {
+	ext := strings.ToLower(filepath.Ext(filename))
+	switch ext {
+	case ".css":
+		return "text/css"
+	default:
+		return "text/plain"
+	}
 }


### PR DESCRIPTION
This PR adds content type detection for raw files, starting with CSS support. This enables CSS files to be properly served with the `text/css` MIME type when linked as external stylesheets.

**Why:**
- When linking to raw CSS files (e.g., `<link href="/raw/HEAD/btn.css">`), browsers require the correct MIME type to apply the styles
- Previously all files were served without specific content types

The list could obviously be expanded for more use cases, but I only require it for CSS personally, for now.