### PR TITLE
feat: read admin group from OIDC token claim

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -103,6 +103,10 @@ oidc.client-key:
 oidc.secret:
 # Discovery endpoint of the OpenID provider. Generally something like http://auth.example.com/.well-known/openid-configuration
 oidc.discovery-url:
+# The name of the claim containing the groups
+oidc.group-claim-name:
+# The name of the group that should receive admin rights
+oidc.admin-group:
 
 # Instance name
 # Set your own custom name to be displayed instead of 'Opengist'

--- a/docs/configuration/oauth-providers.md
+++ b/docs/configuration/oauth-providers.md
@@ -76,4 +76,19 @@ Opengist can be configured to use OAuth to authenticate users, with GitHub, Gite
   # Discovery endpoint of the OpenID provider. Generally something like http://auth.example.com/.well-known/openid-configuration
   OG_OIDC_DISCOVERY_URL=http://auth.example.com/.well-known/openid-configuration
   ```
-  
+
+### OIDC Admin Group
+
+OpenGist supports automatic admin privilege assignment based on OIDC group claims. To configure this feature:
+```yaml
+oidc.group-claim-name: groups        # Name of the claim containing the groups
+oidc.admin-group: admin-group-name   # Name of the group that should receive admin rights
+```
+```shell
+OG_OIDC_GROUP_CLAIM_NAME=groups
+OG_OIDC_ADMIN_GROUP=admin-group-name
+```
+
+The `group-claim-name` must match the name of the claim in your JWT token that contains the groups.
+
+Users who are members of the configured `admin-group` will automatically receive admin privileges in OpenGist. These privileges are synchronized on every login.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,10 +67,12 @@ type config struct {
 	GiteaUrl       string `yaml:"gitea.url" env:"OG_GITEA_URL"`
 	GiteaName      string `yaml:"gitea.name" env:"OG_GITEA_NAME"`
 
-	OIDCProviderName string `yaml:"oidc.provider-name" env:"OG_OIDC_PROVIDER_NAME"`
-	OIDCClientKey    string `yaml:"oidc.client-key" env:"OG_OIDC_CLIENT_KEY"`
-	OIDCSecret       string `yaml:"oidc.secret" env:"OG_OIDC_SECRET"`
-	OIDCDiscoveryUrl string `yaml:"oidc.discovery-url" env:"OG_OIDC_DISCOVERY_URL"`
+	OIDCProviderName   string `yaml:"oidc.provider-name" env:"OG_OIDC_PROVIDER_NAME"`
+	OIDCClientKey      string `yaml:"oidc.client-key" env:"OG_OIDC_CLIENT_KEY"`
+	OIDCSecret         string `yaml:"oidc.secret" env:"OG_OIDC_SECRET"`
+	OIDCDiscoveryUrl   string `yaml:"oidc.discovery-url" env:"OG_OIDC_DISCOVERY_URL"`
+	OIDCGroupClaimName string `yaml:"oidc.group-claim-name" env:"OG_OIDC_GROUP_CLAIM_NAME"`
+	OIDCAdminGroup     string `yaml:"oidc.admin-group" env:"OG_OIDC_ADMIN_GROUP"`
 
 	MetricsEnabled bool `yaml:"metrics.enabled" env:"OG_METRICS_ENABLED"`
 

--- a/templates/pages/admin_config.html
+++ b/templates/pages/admin_config.html
@@ -68,6 +68,8 @@
             <dt>OIDC client Key</dt><dd>{{ if .c.OIDCClientKey }}&#60;defined&#62;{{ end }}</dd>
             <dt>OIDC Secret</dt><dd>{{ if .c.OIDCSecret }}&#60;defined&#62;{{ end }}</dd>
             <dt>OIDC Discovery URL</dt><dd>{{ if .c.OIDCDiscoveryUrl }}&#60;defined&#62;{{ end }}</dd>
+            <dt>OIDC Group Claim Name</dt><dd>{{ .c.OIDCGroupClaimName }}</dd>
+            <dt>OIDC Admin Group</dt><dd>{{ .c.OIDCAdminGroup }}</dd>
         </dl>
     </div>
     <div>


### PR DESCRIPTION
Add the option to read the group for admins from an OIDC token claim.

Related to #160 