### PR TITLE
Fix gist.html using relative URL

### DIFF
--- a/templates/pages/gist.html
+++ b/templates/pages/gist.html
@@ -12,7 +12,7 @@
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-slate-700 dark:text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
                         </svg>
-                        <a href="#file-{{ slug $file.Filename }}" class="hover:text-primary-600 ml-2 mr-1">{{ $file.Filename }}</a>
+                        <a href="{{ $.baseHttpUrl }}/{{ $.gist.User.Username }}/{{ $.gist.Identifier }}#file-{{ slug $file.Filename }}" class="hover:text-primary-600 ml-2 mr-1">{{ $file.Filename }}</a>
                         <span class="hidden sm:block">
                             <span class="text-gray-400"> · {{ $file.HumanSize }} · {{ $file.Type }}</span>
                         </span>


### PR DESCRIPTION
Due to the fact the file templates/base/base_header.html contains a <base> element, all relative URLs are interpreted as dependant on the base.[1]

I've noticed the base isn't the current page, but the element linking to anchor identifier isn't using the complete URL to the gist page, which means that if you go to a gist, and try to click on the link that leads you to the file (which would make browsers automatically go down if it's a file that has a lot of lines), you get taken to the homepage, and unless you look at the URL closely you wouldn't notice the fragment/anchor part.

I'm sure there's a better way of dealing with this, such as removing <base> from the template mentioned above, but due to the fact I'd like to have this work, I've made it put the full URL to this page.

Something that might be good to do is making the relative URLs always be absolute, by having the '{{ $.c.ExternalUrl }}' thing everywhere where a relative URL would be, as that'd probably fix #415, and would allow for this commit to be reverted if that's desired.

[1] https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base