### PR TITLE
Fix Gitlab avatar

### DIFF
--- a/internal/auth/oauth/gitlab.go
+++ b/internal/auth/oauth/gitlab.go
@@ -2,13 +2,17 @@ package oauth
 
 import (
 	gocontext "context"
+	gojson "encoding/json"
+	"io"
+	"net/http"
+
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/gothic"
 	"github.com/markbates/goth/providers/gitlab"
+	"github.com/rs/zerolog/log"
 	"github.com/thomiceli/opengist/internal/config"
 	"github.com/thomiceli/opengist/internal/db"
 	"github.com/thomiceli/opengist/internal/web/context"
-	"net/http"
 )
 
 type GitLabProvider struct {
@@ -77,7 +81,34 @@ func (p *GitLabCallbackProvider) GetProviderUserSSHKeys() ([]string, error) {
 
 func (p *GitLabCallbackProvider) UpdateUserDB(user *db.User) {
 	user.GitlabID = p.User.UserID
-	user.AvatarURL = urlJoin(config.C.GitlabUrl, "/uploads/-/system/user/avatar/", p.User.UserID, "/avatar.png") + "?width=400"
+
+	resp, err := http.Get(urlJoin(config.C.GitlabUrl, "/api/v4/avatar?email=", p.User.Email))
+	if err != nil {
+		log.Error().Err(err).Msg("Cannot get user avatar from GitLab")
+		return
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("Cannot read Gitlab response body")
+		return
+	}
+
+	var result map[string]interface{}
+	err = gojson.Unmarshal(body, &result)
+	if err != nil {
+		log.Error().Err(err).Msg("Cannot unmarshal Gitlab response body")
+		return
+	}
+
+	field, ok := result["avatar_url"]
+	if !ok {
+		log.Error().Msg("Field 'avatar_url' not found in Gitlab JSON response")
+		return
+	}
+
+	user.AvatarURL = field.(string)
 }
 
 func NewGitLabCallbackProvider(user *goth.User) CallbackProvider {

--- a/internal/auth/oauth/gitlab.go
+++ b/internal/auth/oauth/gitlab.go
@@ -82,7 +82,7 @@ func (p *GitLabCallbackProvider) GetProviderUserSSHKeys() ([]string, error) {
 func (p *GitLabCallbackProvider) UpdateUserDB(user *db.User) {
 	user.GitlabID = p.User.UserID
 
-	resp, err := http.Get(urlJoin(config.C.GitlabUrl, "/api/v4/avatar?email=", p.User.Email))
+	resp, err := http.Get(urlJoin(config.C.GitlabUrl, "/api/v4/avatar?size=400&email=", p.User.Email))
 	if err != nil {
 		log.Error().Err(err).Msg("Cannot get user avatar from GitLab")
 		return


### PR DESCRIPTION
Avatars don't work on my self-hosted GitLab via `/uploads/-/system/user/avatar/` URL.
I get a 404 error.

Changed the way to get an avatar for GitLab using [GitLab Api](https://docs.gitlab.com/api/avatar/)

The code base was taken from [Gitea](https://github.com/thomiceli/opengist/blob/master/internal/auth/oauth/gitea.go#L81)