### PR TITLE
feat: add option to remove the link/unlink section in the user settings

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -110,6 +110,9 @@ oidc.discovery-url:
 oidc.group-claim-name:
 # The name of the group that should receive admin rights
 oidc.admin-group:
+# If set to true, users will not be able to unlink their OIDC accounts from the settings page.
+# This ensures users remain authenticated through the configured identity provider.
+oidc.disable-unlink-account: false
 
 # Instance name
 # Set your own custom name to be displayed instead of 'Opengist'

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,12 +70,13 @@ type config struct {
 	GiteaUrl       string `yaml:"gitea.url" env:"OG_GITEA_URL"`
 	GiteaName      string `yaml:"gitea.name" env:"OG_GITEA_NAME"`
 
-	OIDCProviderName   string `yaml:"oidc.provider-name" env:"OG_OIDC_PROVIDER_NAME"`
-	OIDCClientKey      string `yaml:"oidc.client-key" env:"OG_OIDC_CLIENT_KEY"`
-	OIDCSecret         string `yaml:"oidc.secret" env:"OG_OIDC_SECRET"`
-	OIDCDiscoveryUrl   string `yaml:"oidc.discovery-url" env:"OG_OIDC_DISCOVERY_URL"`
-	OIDCGroupClaimName string `yaml:"oidc.group-claim-name" env:"OG_OIDC_GROUP_CLAIM_NAME"`
-	OIDCAdminGroup     string `yaml:"oidc.admin-group" env:"OG_OIDC_ADMIN_GROUP"`
+	OIDCProviderName         string `yaml:"oidc.provider-name" env:"OG_OIDC_PROVIDER_NAME"`
+	OIDCClientKey            string `yaml:"oidc.client-key" env:"OG_OIDC_CLIENT_KEY"`
+	OIDCSecret               string `yaml:"oidc.secret" env:"OG_OIDC_SECRET"`
+	OIDCDiscoveryUrl         string `yaml:"oidc.discovery-url" env:"OG_OIDC_DISCOVERY_URL"`
+	OIDCGroupClaimName       string `yaml:"oidc.group-claim-name" env:"OG_OIDC_GROUP_CLAIM_NAME"`
+	OIDCAdminGroup           string `yaml:"oidc.admin-group" env:"OG_OIDC_ADMIN_GROUP"`
+	OIDCDisableUnlinkAccount bool   `yaml:"oidc.disable-unlink-account" env:"OG_OIDC_DISABLE_UNLINK_ACCOUNT"`
 
 	MetricsEnabled bool `yaml:"metrics.enabled" env:"OG_METRICS_ENABLED"`
 

--- a/internal/web/handlers/settings/settings.go
+++ b/internal/web/handlers/settings/settings.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"github.com/thomiceli/opengist/internal/config"
 	"github.com/thomiceli/opengist/internal/db"
 	"github.com/thomiceli/opengist/internal/web/context"
 )
@@ -29,6 +30,7 @@ func UserSettings(ctx *context.Context) error {
 	ctx.SetData("hasTotp", hasTotp)
 	ctx.SetData("hasPassword", user.Password != "")
 	ctx.SetData("disableForm", ctx.GetData("DisableLoginForm"))
+	ctx.SetData("disableUnlinkAccount", config.C.OIDCDisableUnlinkAccount)
 	ctx.SetData("htmlTitle", ctx.TrH("settings"))
 	return ctx.Html("settings.html")
 }

--- a/templates/pages/settings.html
+++ b/templates/pages/settings.html
@@ -86,7 +86,7 @@
                     </form>
                 </div>
             </div>
-            {{ if or .githubOauth .gitlabOauth .giteaOauth .oidcOauth }}
+            {{ if and (or .githubOauth .gitlabOauth .giteaOauth .oidcOauth) (not .disableUnlinkAccount) }}
             <div class="w-full">
                 <div class="bg-white dark:bg-gray-900 rounded-md border border-1 border-gray-200 dark:border-gray-700 py-8 px-4 shadow sm:rounded-lg sm:px-10">
                     <h2 class="text-md font-bold text-slate-700 dark:text-slate-300 mb-2">


### PR DESCRIPTION
When using OAuth it might make sense to disallow users to unlink their account to prevent them from locking out.