### PR TITLE
File upload form

### DIFF
--- a/public/editor.ts
+++ b/public/editor.ts
@@ -10,6 +10,7 @@ document.addEventListener("DOMContentLoaded", () => {
     let allEditorsdom = document.querySelectorAll("#editors > .editor");
     let firstEditordom = allEditorsdom[0];
 
+    const fileUploadEditorMaxSize = 100 * 1024;  // 100 KB
     const txtFacet = Facet.define<string>({
         combine(values) {
             return values;
@@ -292,8 +293,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
             fileUploadContainer!.appendChild(removeFileBtn);
 
-            // Hide the editor
-            editor.dom.classList.add("hidden-important");
+            // Hide the editor if the file is too large
+            if (file.size > fileUploadEditorMaxSize) {
+                editor.dom.classList.add("hidden-important");
+            }
 
             // set the filename input to the name of the uploaded file
             formfilename!.value = file.name;

--- a/public/editor.ts
+++ b/public/editor.ts
@@ -10,24 +10,6 @@ document.addEventListener("DOMContentLoaded", () => {
     let allEditorsdom = document.querySelectorAll("#editors > .editor");
     let firstEditordom = allEditorsdom[0];
 
-    // Constants for file upload validation
-    const maxUploadFileSize = 10 * 1024 * 1024; // 10 MB
-    const whilelistedImageMimeTypes = [
-      new RegExp("image/.*"),
-    ]
-    const whilelistedTextMimeTypes = [
-      new RegExp("text/.*"),
-      new RegExp("application/(|(.*\\+))json"),
-      new RegExp("application/(|(.*\\+))xml"),
-      new RegExp("application/(|(.*\\+))yaml"),
-      new RegExp("application/(|(.*\\+))javascript"),
-      new RegExp("application/(|(.*\\+))x-.*"),
-    ]
-    const whilelistedMimeTypes = [
-      ...whilelistedImageMimeTypes,
-      ...whilelistedTextMimeTypes,
-    ]
-
     const txtFacet = Facet.define<string>({
         combine(values) {
             return values;
@@ -245,9 +227,8 @@ document.addEventListener("DOMContentLoaded", () => {
     };
 
     document.querySelector<HTMLFormElement>("form#create")!.onsubmit = () => {
-        let j = 0;
-        document.querySelectorAll<HTMLInputElement>(".form-filecontent").forEach((e) => {
-            e.value = encodeURIComponent(editorsjs[j++].state.doc.toString());
+        document.querySelectorAll<HTMLInputElement>(".form-filecontent").forEach((e, j) => {
+            e.value = encodeURIComponent(editorsjs[j].state.doc.toString());
         });
     };
 
@@ -294,18 +275,7 @@ document.addEventListener("DOMContentLoaded", () => {
     ) {
         let fileInput = e.target as HTMLInputElement;
         if (fileInput.files && fileInput.files.length > 0) {
-            // check if the file type is allowed
-            if (!whilelistedMimeTypes.some(mime => mime.test(fileInput.files[0].type))) {
-                alert("File type not allowed. Please upload a valid text or image file.");
-                return false;
-            }
-
-            // check if the file size is within limits
-            if (fileInput.files[0].size > maxUploadFileSize) {
-                alert(`File size exceeds the limit of ${maxUploadFileSize / 1024 / 1024} MB.`);
-                return false;
-            }
-
+            const file = fileInput.files[0];
             const fileUploadContainer = fileInput.closest(".file-upload-container")
             const removeFileBtn = document.createElement("button");
             removeFileBtn.className = "btn btn-secondary btn-sm ml-2";
@@ -317,12 +287,17 @@ document.addEventListener("DOMContentLoaded", () => {
                     changes: {from: 0, to: editor.state.doc.length, insert: ""},
                 });
                 fileUploadContainer!.removeChild(removeFileBtn);
+                editor.dom.classList.remove("hidden-important");
             }
 
             fileUploadContainer!.appendChild(removeFileBtn);
 
+            // Hide the editor
+            editor.dom.classList.add("hidden-important");
+
             // set the filename input to the name of the uploaded file
-            formfilename!.value = fileInput.files[0].name;
+            formfilename!.value = file.name;
+
             // read the file content and set it in the editor
             const reader = new FileReader();
             reader.onload = (event) => {
@@ -330,8 +305,8 @@ document.addEventListener("DOMContentLoaded", () => {
                     changes: {from: 0, to: editor.state.doc.length, insert: event.target!.result as string},
                 });
             };
-            reader.readAsText(fileInput.files[0]);
-            console.log("File read successfully", fileInput.files[0]);
+
+            reader.readAsText(file);
         }
     }
 

--- a/templates/partials/_editor.html
+++ b/templates/partials/_editor.html
@@ -10,6 +10,7 @@
             </button>
         </p>
         <button type="button" class="md-preview hidden whitespace-nowrap text-slate-700 dark:text-slate-300 rounded border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-900 my-2 px-2 text-xs font-medium shadow-sm hover:bg-gray-200 dark:hover:bg-gray-700 hover:border-gray-500 hover:text-slate-700 dark:hover:text-slate-300 focus:outline-none focus:ring-1 focus:border-primary-500 focus:ring-primary-500">{{ $.locale.Tr "gist.new.preview" }}</button>
+
         <div class="hidden mx-2 my-2 sm:inline-flex ml-auto space-x-2">
             <select class="editor-indent-type whitespace-nowrap text-slate-700 dark:text-slate-300 rounded border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-900 pr-8 text-xs font-medium shadow-sm hover:bg-gray-200 dark:hover:bg-gray-700 hover:border-gray-500 hover:text-slate-700 dark:hover:text-slate-300 focus:outline-none focus:ring-1 focus:border-primary-500 focus:ring-primary-500">
                 <optgroup label="{{ $.locale.Tr "gist.new.indent-mode" }}">
@@ -34,5 +35,8 @@
     </div>
     <input type="hidden" value="{{ .Content }}" name="content" class="form-filecontent" autocomplete="off">
     <div class="hidden preview chroma markdown markdown-body p-8"></div>
+    <div class="file-upload-container p-4">
+        <input name="file-upload" type="file" class="text-sm text-gray-500 dark:text-slate-300 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-gray-100 dark:file:bg-gray-600 file:text-gray-700 dark:file:text-white hover:file:bg-gray-200 dark:hover:file:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
+    </div>
 </div>
 {{ end }}

--- a/templates/partials/_editor.html
+++ b/templates/partials/_editor.html
@@ -35,7 +35,7 @@
     </div>
     <input type="hidden" value="{{ .Content }}" name="content" class="form-filecontent" autocomplete="off">
     <div class="hidden preview chroma markdown markdown-body p-8"></div>
-    <div class="file-upload-container p-4">
+    <div class="file-upload-container p-2">
         <input name="file-upload" type="file" class="text-sm text-gray-500 dark:text-slate-300 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-gray-100 dark:file:bg-gray-600 file:text-gray-700 dark:file:text-white hover:file:bg-gray-200 dark:hover:file:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
     </div>
 </div>


### PR DESCRIPTION
<img width="998" height="618" alt="screenshot_2025-08-19T02:09:14" src="https://github.com/user-attachments/assets/1ee6c552-4b2c-4de5-8fa3-781ddccfab0d" />

Adds a file upload input to the editors.

Note that this doesn't cover yet binary files, as suggested in https://github.com/thomiceli/opengist/pull/491#issuecomment-3195889129.

This probably requires resuming the discussion at #377 and:

- Decide which file types we want to allow (if any)
- Rewrite most of the submit logic in `editor.ts`, which currently does a big `encodeURIComponent` with `toString` of whatever is in the editor, to support binary content instead

https://github.com/thomiceli/opengist/blob/d53715378598a42b68819a327bf684e48955d2c3/public/editor.ts#L224

Closes #499