### PR TITLE
fix: reduce footprint of docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apk update && \
         apk add --no-cache \
         make \
         gcc \
+        git \
         musl-dev \
         libstdc++
 


### PR DESCRIPTION
- bump to alpine 3.22
- don't add build dependencies to final image
- add runtime depencies, devtools to dev image

Alpine 3.22 is just to bump all dependencies up for latest security updates + patches
Removing dependencies from other layers dramatically reduces the image size 

FYI NodeJS 20 is EOL https://endoflife.date/nodejs, you might want to aim for 24 LTS since 22 is on it's way out