### PR TITLE
fix(OAuth / Gitea): Request to fetch user details/avatar URL from Gitea API

### DIFF
--- a/internal/auth/oauth/gitea.go
+++ b/internal/auth/oauth/gitea.go
@@ -81,7 +81,14 @@ func (p *GiteaCallbackProvider) GetProviderUserSSHKeys() ([]string, error) {
 func (p *GiteaCallbackProvider) UpdateUserDB(user *db.User) {
 	user.GiteaID = p.User.UserID
 
-	resp, err := http.Get(urlJoin(config.C.GiteaUrl, "/api/v1/users/", p.User.UserID))
+	req, err := http.NewRequest("GET", urlJoin(config.C.GiteaUrl, "/api/v1/user"), http.NoBody)
+	if err != nil {
+		log.Error().Err(err).Msg("Cannot create Gitea API request")
+		return
+	}
+	req.Header.Set("Authorization", "token "+p.User.AccessToken)
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Error().Err(err).Msg("Cannot get user from Gitea")
 		return


### PR DESCRIPTION
# Request to fetch user details/avatar URL from Gitea API with proper authorization

## Current problem

When logging to OpenGist though a Gitea instance account, we get an error when dealing with the Gitea API :

```json
{
    "level": "error",
    "caller": "/home/runner/work/opengist/opengist/internal/auth/oauth/gitea.go:106",
    "time": "2026-03-17T16:59:23Z",
    "message": "Field 'avatar_url' not found in Gitea JSON response"
}
```
*(message taken from the log file)*

The "problematic" method is : https://github.com/thomiceli/opengist/blob/master/internal/auth/oauth/gitea.go#L81-L111

## First considered solution

I planned to replace `UserId` with `NickName` when calling [`/api/v1/users/:user`](https://gitea.com/api/swagger#/user/userGet) route; however, this does not work for users that have chosen to set their profile as "Limited" or "Private" in the [user settings](https://gitea.com/user/settings).

## Proposed solution

Use the [`/api/v1/user`](https://gitea.com/api/swagger#/user/userGetCurrent) route with the signed in user's access token  :

```http
GET /api/v1/user HTTP/1.1
Host: gitea.com
Authorization: token USER_ACCESS_TOKEN
```

This allows for all users to fetch their information from the Gitea API, independently of their profile's privacy settings.