### PR TITLE
fix: apply `topics` push option in post-receive hook

### DIFF
--- a/docs/usage/git-push-options.md
+++ b/docs/usage/git-push-options.md
@@ -30,3 +30,9 @@ git push -o visibility=public
 git push -o visibility=unlisted
 git push -o visibility=private
 ```
+
+## Change topics
+
+```shell
+git push -o topics="golang devops"
+```

--- a/internal/hooks/post_receive.go
+++ b/internal/hooks/post_receive.go
@@ -70,6 +70,17 @@ func PostReceive(in io.Reader, out, er io.Writer) error {
 		outputSb.WriteString(fmt.Sprintf("Gist description set to \"%s\"\n\n", opts["description"]))
 	}
 
+	if opts["topics"] != "" && validator.Var(opts["topics"], "gisttopics") == nil {
+		topicNames := strings.Fields(opts["topics"])
+		if len(topicNames) > 0 {
+			gist.Topics = make([]db.GistTopic, 0, len(topicNames))
+			for _, name := range topicNames {
+				gist.Topics = append(gist.Topics, db.GistTopic{Topic: name})
+			}
+			outputSb.WriteString(fmt.Sprintf("Gist topics set to \"%s\"\n\n", opts["topics"]))
+		}
+	}
+
 	if hasNoCommits, err := git.HasNoCommits(gist.User.Username, gist.Uuid); err != nil {
 		_, _ = fmt.Fprintln(er, "Failed to check if gist has no commits")
 		return fmt.Errorf("failed to check if gist has no commits: %w", err)


### PR DESCRIPTION
Closes #697

The `topics` push option was parsed into the options map but never read by the post-receive hook — any topics passed via `git push -o topics=...`were silently dropped. Mirrors the existing `title`/`description` handling and reuses the `gisttopics` validator.

Verified locally end-to-end (create, update, validator rejection, empty input as no-op).

No tests added — `post_receive.go` doesn't currently have unit tests for the other push-option fields either, so I matched that. Happy to add one if you'd prefer.