### PR TITLE
Allow underscores in usernames

### DIFF
--- a/internal/db/user.go
+++ b/internal/db/user.go
@@ -267,7 +267,7 @@ type UserDTO struct {
 }
 
 type OAuthRegisterDTO struct {
-	Username string `form:"username" validate:"required,max=24,alphanumdash,notreserved"`
+	Username string `form:"username" validate:"required,max=24,alphanumdashunder,notreserved"`
 	Email    string `form:"email" validate:"omitempty,email"`
 }
 

--- a/internal/i18n/locales/en-US.yml
+++ b/internal/i18n/locales/en-US.yml
@@ -379,6 +379,7 @@ validation.should-not-be-empty: Field %s should not be empty
 validation.should-not-include-sub-directory: Field %s should not include a sub directory
 validation.should-only-contain-alphanumeric-characters: Field %s should only contain alphanumeric characters
 validation.should-only-contain-alphanumeric-characters-and-dashes: Field %s should only contain alphanumeric characters and dashes
+validation.should-only-contain-alphanumeric-characters-and-dashes-and-underscores: Field %s should only contain alphanumeric characters, dashes and underscores
 validation.not-enough: Not enough %s
 validation.invalid: Invalid %s
 validation.invalid-gist-topics: Invalid gist topics, they must start with a letter or number, consist of 50 characters or less, and can include hyphens

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -16,6 +16,8 @@ func NewValidator() *OpengistValidator {
 	_ = v.RegisterValidation("notreserved", validateReservedKeywords)
 	_ = v.RegisterValidation("alphanumdash", validateAlphaNumDash)
 	_ = v.RegisterValidation("alphanumdashorempty", validateAlphaNumDashOrEmpty)
+	_ = v.RegisterValidation("alphanumdashunder", validateAlphaNumDashUnder)
+	_ = v.RegisterValidation("alphanumdashunderorempty", validateAlphaNumDashUnderOrEmpty)
 	_ = v.RegisterValidation("gisttopics", validateGistTopics)
 	return &OpengistValidator{v}
 }
@@ -43,6 +45,8 @@ func ValidationMessages(err *error, locale *i18n.Locale) string {
 			messages[i] = locale.String("validation.should-only-contain-alphanumeric-characters", e.Field())
 		case "alphanumdash", "alphanumdashorempty":
 			messages[i] = locale.String("validation.should-only-contain-alphanumeric-characters-and-dashes", e.Field())
+		case "alphanumdashunder", "alphanumdashunderorempty":
+			messages[i] = locale.String("validation.should-only-contain-alphanumeric-characters-and-dashes-and-underscores", e.Field())
 		case "min":
 			messages[i] = locale.String("validation.not-enough", e.Field())
 		case "notreserved":
@@ -74,6 +78,14 @@ func validateAlphaNumDash(fl validator.FieldLevel) bool {
 
 func validateAlphaNumDashOrEmpty(fl validator.FieldLevel) bool {
 	return regexp.MustCompile(`^$|^[a-zA-Z0-9-]+$`).MatchString(fl.Field().String())
+}
+
+func validateAlphaNumDashUnder(fl validator.FieldLevel) bool {
+	return regexp.MustCompile(`^[a-zA-Z0-9-_]+$`).MatchString(fl.Field().String())
+}
+
+func validateAlphaNumDashUnderOrEmpty(fl validator.FieldLevel) bool {
+	return regexp.MustCompile(`^$|^[a-zA-Z0-9-_]+$`).MatchString(fl.Field().String())
 }
 
 func validateGistTopics(fl validator.FieldLevel) bool {


### PR DESCRIPTION
# Summary
Some organizations use underscores in github usernames. Filtering those out prevents a smooth user creation process. This PR adds underscores to the "alphanumeric characters and dash" filter.

# Test Plan
Tested it in an organization with underscores in the usernames: it works.