### PR TITLE
Add support for `gh` token auth

### DIFF
--- a/internal/auth/try_login.go
+++ b/internal/auth/try_login.go
@@ -1,11 +1,16 @@
 package auth
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
 
 	"github.com/rs/zerolog/log"
 	"github.com/thomiceli/opengist/internal/auth/ldap"
 	passwordpkg "github.com/thomiceli/opengist/internal/auth/password"
+	"github.com/thomiceli/opengist/internal/config"
 	"github.com/thomiceli/opengist/internal/db"
 	"gorm.io/gorm"
 )
@@ -29,12 +34,24 @@ func TryAuthentication(username, password string) (*db.User, error) {
 
 	if user.Password != "" {
 		return tryDbLogin(user, password)
-	} else {
-		if ldap.Enabled() {
-			return tryLdapLogin(username, password)
-		}
-		return nil, AuthError{"no authentication method available"}
 	}
+
+	if ldap.Enabled() {
+		return tryLdapLogin(username, password)
+	}
+
+	// Try GitHub token authentication if GitHub OAuth is configured
+	if config.C.GithubClientKey != "" {
+		// If the user was found by username and has a GithubID, try token auth directly
+		if user.GithubID != "" {
+			return tryGithubTokenLogin(user, password)
+		}
+		// If username lookup failed, try authenticating the token first,
+		// then match by GitHub user ID
+		return tryGithubTokenLoginByToken(password)
+	}
+
+	return nil, AuthError{"no authentication method available"}
 }
 
 func tryDbLogin(user *db.User, password string) (*db.User, error) {
@@ -77,6 +94,74 @@ func tryLdapLogin(username, password string) (user *db.User, err error) {
 		}
 
 		return user, nil
+	}
+
+	return user, nil
+}
+
+func tryGithubTokenLogin(user *db.User, token string) (*db.User, error) {
+	req, err := http.NewRequest("GET", "https://api.github.com/user", nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create GitHub API request: %w", err)
+	}
+	req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot reach GitHub API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, AuthError{"invalid GitHub token"}
+	}
+
+	var ghUser struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&ghUser); err != nil {
+		return nil, fmt.Errorf("cannot decode GitHub API response: %w", err)
+	}
+
+	if strconv.FormatInt(ghUser.ID, 10) != user.GithubID {
+		return nil, AuthError{"GitHub token does not match user"}
+	}
+
+	return user, nil
+}
+
+// tryGithubTokenLoginByToken validates a GitHub token and looks up the Opengist user
+// by GitHub user ID, regardless of what username was provided.
+func tryGithubTokenLoginByToken(token string) (*db.User, error) {
+	req, err := http.NewRequest("GET", "https://api.github.com/user", nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create GitHub API request: %w", err)
+	}
+	req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot reach GitHub API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, AuthError{"invalid GitHub token"}
+	}
+
+	var ghUser struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&ghUser); err != nil {
+		return nil, fmt.Errorf("cannot decode GitHub API response: %w", err)
+	}
+
+	ghID := strconv.FormatInt(ghUser.ID, 10)
+	user, err := db.GetUserByProvider(ghID, "github")
+	if err != nil {
+		return nil, AuthError{"no Opengist user linked to this GitHub account"}
 	}
 
 	return user, nil


### PR DESCRIPTION
# Summary
In some organizations, ssh keys are disabled for listing. In these orgs, github operatoins happen with the `gh auth git-credential get` helper. To make it smooth for people who choose to use `gh auth` as a client, this PR sends the password (ie token) to github for verification. This behavior is gated to only when we have github client key is configured (ie: we're using it to authenticate people).

# Test Plan
Tested it in an organization which uses github oauth2 and people use `gh` cli in their .gitconfig