### PR TITLE
Make ssh import failure a warning

### DIFF
--- a/internal/auth/oauth/gitea.go
+++ b/internal/auth/oauth/gitea.go
@@ -2,7 +2,7 @@ package oauth
 
 import (
 	gocontext "context"
-
+	"fmt"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -73,6 +73,10 @@ func (p *GiteaCallbackProvider) GetProviderUserSSHKeys() ([]string, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Gitea API returned status code %d", resp.StatusCode)
+	}
 
 	return readKeys(resp)
 }

--- a/internal/auth/oauth/gitea.go
+++ b/internal/auth/oauth/gitea.go
@@ -75,7 +75,7 @@ func (p *GiteaCallbackProvider) GetProviderUserSSHKeys() ([]string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("Gitea API returned status code %d", resp.StatusCode)
+		return nil, fmt.Errorf("gitea API returned status code %d", resp.StatusCode)
 	}
 
 	return readKeys(resp)

--- a/internal/auth/oauth/github.go
+++ b/internal/auth/oauth/github.go
@@ -2,13 +2,15 @@ package oauth
 
 import (
 	gocontext "context"
+	"fmt"
+	"net/http"
+
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/gothic"
 	"github.com/markbates/goth/providers/github"
 	"github.com/thomiceli/opengist/internal/config"
 	"github.com/thomiceli/opengist/internal/db"
 	"github.com/thomiceli/opengist/internal/web/context"
-	"net/http"
 )
 
 type GitHubProvider struct {
@@ -68,6 +70,10 @@ func (p *GitHubCallbackProvider) GetProviderUserSSHKeys() ([]string, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("GitHub API returned status code %d", resp.StatusCode)
+	}
 
 	return readKeys(resp)
 }

--- a/internal/auth/oauth/gitlab.go
+++ b/internal/auth/oauth/gitlab.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	gocontext "context"
 	gojson "encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -75,6 +76,10 @@ func (p *GitLabCallbackProvider) GetProviderUserSSHKeys() ([]string, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("GitLab API returned status code %d", resp.StatusCode)
+	}
 
 	return readKeys(resp)
 }

--- a/internal/i18n/locales/en-US.yml
+++ b/internal/i18n/locales/en-US.yml
@@ -354,7 +354,7 @@ flash.auth.username-exists: Username already exists
 flash.auth.invalid-credentials: Invalid credentials
 flash.auth.account-linked-oauth: Account linked to %s
 flash.auth.account-unlinked-oauth: Account unlinked from %s
-flash.auth.user-sshkeys-not-retrievable: Could not get user keys
+flash.auth.user-sshkeys-not-retrievable: Could not import SSH keys from your provider. Your account was created, but you may need to add your SSH keys manually.
 flash.auth.user-sshkeys-not-created: Could not create ssh key
 flash.auth.must-be-logged-in: You must be logged in to access gists
 flash.auth.passkey-registred: Passkey %s registered

--- a/internal/web/handlers/auth/oauth.go
+++ b/internal/web/handlers/auth/oauth.go
@@ -246,7 +246,7 @@ func ProcessOauthRegister(ctx *context.Context) error {
 
 	keys, err := callbackProvider.GetProviderUserSSHKeys()
 	if err != nil {
-		ctx.AddFlash(ctx.Tr("flash.auth.user-sshkeys-not-retrievable"), "error")
+		ctx.AddFlash(ctx.Tr("flash.auth.user-sshkeys-not-retrievable"), "warning")
 		log.Error().Err(err).Msg("Could not get user keys")
 	} else {
 		for _, key := range keys {


### PR DESCRIPTION
# Summary
Some organizations make user profiles not publicly readable. In these cases, ssh key import fails. While that is unfortunate, the user creation still succeeds, but a big error message is presented to users, which is confusing. To address the fact that profile creation happens even without a successful ssh key import, this PR changes the severity of that UI widget to a warning.

# Test Plan
Tested it in an organization where ssh keys are not publicly listable; therefore this case is always present at registration. Observed that now the issue is a warning.