### PR TITLE
Embedding fix vertical scrolling and improve padding

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -26,6 +26,7 @@ pre {
 
 .code {
     font-family: Menlo,Consolas,Liberation Mono,monospace;
+    overflow-x: auto;
 }
 
 .code .line-num {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -27,6 +27,7 @@ pre {
 .code {
     font-family: Menlo,Consolas,Liberation Mono,monospace;
     overflow-x: auto;
+    padding: 5px 10px 5px;
 }
 
 .code .line-num {


### PR DESCRIPTION
I lpayed around with the embedding more and embedded content that was wider than the actual viewport. When scrolling vertically, the background "ends" upon scrolling. This PR (first commit) addresses this. This simple line also accidentally fixes the scrolling header section (which shouldn't scroll)

<img width="916" height="325" alt="image" src="https://github.com/user-attachments/assets/72eea6fa-8245-405b-966e-1c7912e4d956" />

The second commit introduces very subtile padding on the upper, lower and right side of the code. This visually improves the readability, because the text isn't as crowded in the borders anymore.

<img width="311" height="253" alt="image" src="https://github.com/user-attachments/assets/2570062d-4f20-43fb-942a-70ab9f37b55a" />

<img width="880" height="236" alt="image" src="https://github.com/user-attachments/assets/9f641b3f-2f33-4abd-b765-e617c106b178" />
