### PR TITLE
Allow copying embedded gists

### DIFF
--- a/internal/web/handlers/gist/gist.go
+++ b/internal/web/handlers/gist/gist.go
@@ -268,6 +268,15 @@ func escapeJavaScriptContent(htmlContent, cssUrl, themeUrl string, autoMode bool
                     mq.addEventListener('change', applyTheme);
                     applyTheme();
                 }
+                this.shadowRoot.querySelectorAll('.copy-embed-btn').forEach(function(btn) {
+                    btn.addEventListener('click', function() {
+                        var block = btn.closest('.rounded-md');
+                        var el = block && block.querySelector('.gist-content');
+                        navigator.clipboard.writeText(el ? el.textContent : '').catch(function(err) {
+                            console.error('Could not copy text: ', err);
+                        });
+                    });
+                });
             }
         });
     }

--- a/public/ts/embed.ts
+++ b/public/ts/embed.ts
@@ -1,1 +1,12 @@
 import "../css/embed.css"
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll<HTMLElement>('.copy-embed-btn').forEach((btn) => {
+        btn.addEventListener('click', () => {
+            const content = btn.closest('.rounded-md')?.querySelector<HTMLElement>('.gist-content')?.textContent || '';
+            navigator.clipboard.writeText(content).catch((err) => {
+                console.error('Could not copy text: ', err);
+            });
+        });
+    });
+});

--- a/public/ts/embed.ts
+++ b/public/ts/embed.ts
@@ -1,12 +1,1 @@
 import "../css/embed.css"
-
-document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll<HTMLElement>('.copy-embed-btn').forEach((btn) => {
-        btn.addEventListener('click', () => {
-            const content = btn.closest('.rounded-md')?.querySelector<HTMLElement>('.gist-content')?.textContent || '';
-            navigator.clipboard.writeText(content).catch((err) => {
-                console.error('Could not copy text: ', err);
-            });
-        });
-    });
-});

--- a/templates/pages/gist_embed.html
+++ b/templates/pages/gist_embed.html
@@ -4,8 +4,9 @@
         <div class="rounded-md border-1 border-gray-100 dark:border-gray-800 overflow-auto mb-4">
             <div class="border-b-1 border-gray-100 dark:border-gray-700 text-xs p-2 pl-4 bg-gray-50 dark:bg-gray-800 text-gray-400">
                 <a target="_blank" class="font-sans" href="{{ $.baseHttpUrl }}/{{ $.gist.User.Username }}/{{ $.gist.Identifier }}#file-{{ slug $file.Filename }}"><span class="font-bold text-gray-700 dark:text-gray-200">{{ $file.Filename }}</span> &middot; {{ $file.HumanSize }} &middot; {{ $file.Type }}</a>
-                <span class="float-right font-sans"><a target="_blank" href="{{ $.baseHttpUrl }}">Hosted via Opengist</a> &middot; <span class="text-gray-700 dark:text-gray-200 font-bold"><a target="_blank" href="{{ $.baseHttpUrl }}/{{ $.gist.User.Username }}/{{ $.gist.Identifier }}/raw/HEAD/{{$file.Filename}}">view raw</a></span></span>
+                <span class="float-right font-sans"><a target="_blank" href="{{ $.baseHttpUrl }}">Hosted via Opengist</a> &middot; <span class="text-gray-700 dark:text-gray-200 font-bold"><a target="_blank" href="{{ $.baseHttpUrl }}/{{ $.gist.User.Username }}/{{ $.gist.Identifier }}/raw/HEAD/{{$file.Filename}}">view raw</a></span>{{ if $file.MimeType.IsText }} &middot; <span class="text-gray-700 dark:text-gray-200 font-bold"><button class="copy-embed-btn cursor-pointer bg-transparent border-0 p-0">copy</button></span>{{ end }}</span>
             </div>
+            {{ if $file.MimeType.IsText }}<div class="hidden gist-content">{{ $file.Content }}</div>{{ end }}
             {{ if and $file.Truncated $file.MimeType.IsText }}
                 <div class="text-xs px-4 bg-gray-50 py-1.5 border-b-1 border-gray-100 dark:border-gray-700">
                     {{ $.locale.Tr "gist.file-truncated" }} <a target="_blank" class="text-primary-600" href="{{ $.baseHttpUrl }}/{{ $.gist.User.Username }}/{{ $.gist.Identifier }}/raw/HEAD/{{$file.Filename}}">{{ $.locale.Tr "gist.watch-full-file" }}</a>


### PR DESCRIPTION
Embedded Gists currently do not allow copying the files content - but the main pages allows it. This commit brings the functionality to embeds as well.

<img width="922" height="257" alt="image" src="https://github.com/user-attachments/assets/686e5b50-6135-4ddb-967a-304d17d7b523" />
