### PR TITLE
feat: display version in footer

### DIFF
--- a/internal/web/server/middlewares.go
+++ b/internal/web/server/middlewares.go
@@ -165,6 +165,7 @@ func dataInit(next Handler) Handler {
 
 		ctx.SetData("baseHttpUrl", baseHttpUrl)
 		ctx.SetData("canonicalUrl", baseHttpUrl+ctx.Request().URL.Path)
+		ctx.SetData("opengistVersion", config.OpengistVersion)
 
 		return next(ctx)
 	}

--- a/templates/base/base_footer.html
+++ b/templates/base/base_footer.html
@@ -10,6 +10,9 @@
                 <a target="_blank" style="margin-left: 0 !important;" class="text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 inline-flex" href="https://github.com/thomiceli/opengist">
                     <span class="mr-1">{{ .locale.Tr "footer.powered-by" "<span class=\"font-bold dark:text-slate-300\">Opengist</span>" }} </span>
                 </a>
+                {{ if .opengistVersion }}
+                    <a target="_blank" class="text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 inline-flex" href="https://github.com/thomiceli/opengist/releases/tag/{{ .opengistVersion }}">{{ .opengistVersion }}</a>
+                {{ end }}
             </span>⋅
             <span>Load: <span class="font-bold dark:text-slate-300">{{ loadedTime .loadStartTime }}</span></span>⋅
         </p>


### PR DESCRIPTION
Add the running server version next to the 'Powered by Opengist' text in the footer, linking to the corresponding GitHub release page.

- Expose opengistVersion globally via dataInit middleware (previously only available in the admin panel)
- Render version as a release link in base_footer.html, guarded by an empty-check so dev builds without a tag show nothing
