### PR TITLE
fix(frontend): cleanup CSS to silence warnings

### DIFF
--- a/public/css/embed.css
+++ b/public/css/embed.css
@@ -1,3 +1,5 @@
+@import "tailwindcss";
+
 @plugin "@tailwindcss/typography";
 @plugin "@tailwindcss/forms";
 
@@ -41,21 +43,15 @@
         --tw-border-width: 0;
         display: block;
     }
-}
 
-.opengist-embed {
-    @import "tailwindcss";
-    @layer base {
-        ul, ol {
-            list-style: revert;
-        }
-
-        button:not(:disabled),
-        [role="button"]:not(:disabled) {
-            cursor: pointer;
-        }
-
-        @import './ipynb.css';
-        @import "./style.css";
+    ul, ol {
+        list-style: revert;
     }
+
+    button:not(:disabled),
+    [role="button"]:not(:disabled) {
+        cursor: pointer;
+    }
+
+    @import "./style.css";
 }


### PR DESCRIPTION
This seems to address the multiple warnings currently thrown by Vite, e.g:

```
#32 13.41 vite v8.0.16 building client environment for production...
#32 13.43 
transforming...Found 22 warnings while optimizing generated CSS:
#32 14.10 
#32 14.10 Issue #1:
#32 14.10 │       cursor: pointer;
#32 14.10 │     }
#32 14.10 │     @font-face {
#32 14.10 ┆               ^-- Unknown at rule: @font-face
#32 14.10 ┆
#32 14.10 │       font-display: block;
#32 14.10 │       font-family: KaTeX_AMS;
#32 14.10 
```

See https://github.com/shaftoe/opengist/actions/runs/28580874938/job/84740560440#step:7:593 for a full list