### PR TITLE
feat: rationalize logging

### DIFF
--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -146,7 +145,7 @@ func syncGistPreviews() {
 		return
 	}
 	for _, gist := range gists {
-		fmt.Println("Syncing preview for gist", gist.ID)
+		log.Info().Msgf("Syncing preview for gist %d", gist.ID)
 		if err = gist.UpdatePreviewAndCount(false); err != nil {
 			log.Error().Err(err).Msgf("Cannot update preview and count for gist %d", gist.ID)
 		}

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -26,10 +26,11 @@ func cliError(format string, a ...any) error {
 }
 
 func initialize(ctx *cli.Context) {
-	if err := config.InitConfig(ctx.String("config"), io.Discard); err != nil {
+	if err := config.InitConfig(ctx.String("config")); err != nil {
 		panic(err)
 	}
 	config.InitLog()
+	config.FlushStartupLog()
 
 	db.DeprecationDBFilename()
 	if err := db.Setup(config.C.DBUri); err != nil {

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -78,10 +78,11 @@ func App() error {
 }
 
 func Initialize(ctx *cli.Context) {
-	fmt.Println("Opengist " + config.OpengistVersion)
+	config.AddStartupMsg("Opengist " + config.OpengistVersion)
 
-	if err := config.InitConfig(ctx.String("config"), os.Stdout); err != nil {
-		panic(err)
+	if err := config.InitConfig(ctx.String("config")); err != nil {
+		fmt.Fprintf(os.Stderr, "Fatal: %s\n", err)
+		os.Exit(1)
 	}
 	if err := os.MkdirAll(filepath.Join(config.GetHomeDir()), 0755); err != nil {
 		panic(err)
@@ -90,6 +91,7 @@ func Initialize(ctx *cli.Context) {
 	config.SetupSecretKey()
 
 	config.InitLog()
+	config.FlushStartupLog()
 
 	gitVersion, err := git.GetGitVersion()
 	if err != nil {

--- a/internal/cli/subprocess.go
+++ b/internal/cli/subprocess.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"io"
-
 	"github.com/thomiceli/opengist/internal/config"
 	"github.com/urfave/cli/v2"
 )
@@ -18,7 +16,7 @@ import (
 //   - it opens no database: subprocesses talk to the running daemon's internal
 //     API instead. Use subprocessInitClient when that API is needed.
 func subprocessInit(ctx *cli.Context) {
-	if err := config.InitConfig(ctx.String("config"), io.Discard); err != nil {
+	if err := config.InitConfig(ctx.String("config")); err != nil {
 		panic(err)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"net/url"
@@ -25,6 +26,25 @@ var OpengistVersion = ""
 var C *config
 
 var SecretKey []byte
+
+// startupMessages buffers informational messages produced during config loading
+// (before the logger is configured). Call FlushStartupLog after InitLog to
+// replay them through the configured logger.
+var startupMessages []string
+
+// AddStartupMsg records a message to be logged once the logger is configured.
+func AddStartupMsg(msg string) {
+	startupMessages = append(startupMessages, msg)
+}
+
+// FlushStartupLog replays all buffered startup messages through the configured
+// logger. It should be called after InitLog.
+func FlushStartupLog() {
+	for _, msg := range startupMessages {
+		log.Info().Msg(msg)
+	}
+	startupMessages = nil
+}
 
 // SSH server modes: the canonical values of ssh.git-enabled. The legacy
 // booleans are still accepted (true → builtin, false → disabled).
@@ -171,18 +191,24 @@ func configWithDefaults() (*config, error) {
 	return c, nil
 }
 
-func InitConfig(configPath string, out io.Writer) error {
+func InitConfig(configPath string) error {
 	// Default values
 	c, err := configWithDefaults()
 	if err != nil {
 		return err
 	}
 
-	if err = loadConfigFromYaml(c, configPath, out); err != nil {
+	if err = loadConfigFromYaml(c, configPath); err != nil {
 		return err
 	}
 
-	if err = loadConfigFromEnv(c, out); err != nil {
+	// Source Docker secrets (a dotenv-style file) into the environment before
+	// reading OG_* variables. Explicit environment variables take precedence.
+	if err = loadSecretsFile(); err != nil {
+		return err
+	}
+
+	if err = loadConfigFromEnv(c); err != nil {
 		return err
 	}
 
@@ -324,7 +350,91 @@ func SetupSecretKey() {
 	}
 }
 
-func loadConfigFromYaml(c *config, configPath string, out io.Writer) error {
+// defaultSecretsFile is the path Docker Compose/Swarm mounts the secrets file
+// at (see docs/configuration/configure.md). It can be overridden via the
+// OG_SECRETS_FILE environment variable.
+const defaultSecretsFile = "/run/secrets/opengist_secrets"
+
+// loadSecretsFile sources a dotenv-style file (as mounted by Docker
+// Compose/Swarm secrets) into the process environment, so that its values can
+// be picked up by loadConfigFromEnv like any other OG_* variable. It is a
+// no-op when the file is absent, which keeps non-containerized deployments
+// unaffected.
+//
+// Variables already present in the environment are left untouched, so explicit
+// configuration always takes precedence over the secrets file.
+func loadSecretsFile() error {
+	path := os.Getenv("OG_SECRETS_FILE")
+	if path == "" {
+		path = defaultSecretsFile
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return nil
+	}
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		key, value, ok := parseSecretLine(scanner.Text())
+		if !ok {
+			continue
+		}
+		if _, isSet := os.LookupEnv(key); !isSet {
+			if err := os.Setenv(key, value); err != nil {
+				return err
+			}
+		}
+	}
+
+	return scanner.Err()
+}
+
+// parseSecretLine parses a single dotenv-style line into a key/value pair. It
+// supports an optional "export " prefix, blank lines and comments (#), and
+// strips a single layer of surrounding single or double quotes. ok is false
+// for lines that do not define a variable.
+func parseSecretLine(line string) (key, value string, ok bool) {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", "", false
+	}
+
+	line = strings.TrimPrefix(line, "export ")
+	key, value, found := strings.Cut(line, "=")
+	if !found {
+		return "", "", false
+	}
+
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "", "", false
+	}
+
+	value = strings.TrimSpace(value)
+	if n := len(value); n >= 2 {
+		first, last := value[0], value[n-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			value = value[1 : n-1]
+		}
+	}
+
+	return key, value, true
+}
+
+func loadConfigFromYaml(c *config, configPath string) error {
 	if configPath != "" {
 		absolutePath, _ := filepath.Abs(configPath)
 		absolutePath = filepath.Clean(absolutePath)
@@ -333,9 +443,9 @@ func loadConfigFromYaml(c *config, configPath string, out io.Writer) error {
 			if !os.IsNotExist(err) {
 				return err
 			}
-			_, _ = fmt.Fprintln(out, "No YAML config file found at "+absolutePath)
+			AddStartupMsg("No YAML config file found at " + absolutePath)
 		} else {
-			_, _ = fmt.Fprintln(out, "Using YAML config file: "+absolutePath)
+			AddStartupMsg("Using YAML config file: " + absolutePath)
 
 			// Override default values with values from config.yml
 			d := yaml.NewDecoder(file)
@@ -345,13 +455,13 @@ func loadConfigFromYaml(c *config, configPath string, out io.Writer) error {
 			defer file.Close()
 		}
 	} else {
-		_, _ = fmt.Fprintln(out, "No YAML config file specified.")
+		AddStartupMsg("No YAML config file specified.")
 	}
 
 	return nil
 }
 
-func loadConfigFromEnv(c *config, out io.Writer) error {
+func loadConfigFromEnv(c *config) error {
 	v := reflect.ValueOf(c).Elem()
 	var envVars []string
 
@@ -423,9 +533,9 @@ func loadConfigFromEnv(c *config, out io.Writer) error {
 	}
 
 	if len(envVars) > 0 {
-		_, _ = fmt.Fprintln(out, "Using environment variables config: "+strings.Join(envVars, ", "))
+		AddStartupMsg("Using environment variables config: " + strings.Join(envVars, ", "))
 	} else {
-		_, _ = fmt.Fprintln(out, "No environment variables config specified.")
+		AddStartupMsg("No environment variables config specified.")
 	}
 
 	return nil

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -1,12 +1,11 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 )
 
-// auto migration for newer versions of Opengist
+// auto migration for newer versions of Opengist.
 func migrateConfig() error {
 	configMigrations := []struct {
 		Version string
@@ -37,6 +36,6 @@ func moveFile(oldPath, newPath string) {
 	}
 
 	if err := os.Rename(oldPath, newPath); err == nil {
-		fmt.Printf("Automatically moved %s to %s\n", oldPath, newPath)
+		AddStartupMsg("Automatically moved " + oldPath + " to " + newPath)
 	}
 }

--- a/internal/git/test_funcs.go
+++ b/internal/git/test_funcs.go
@@ -3,7 +3,6 @@ package git
 import (
 	"github.com/stretchr/testify/require"
 	"github.com/thomiceli/opengist/internal/config"
-	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -15,7 +14,7 @@ import (
 func SetupTest(t *testing.T) {
 	_ = os.Setenv("OPENGIST_SKIP_GIT_HOOKS", "1")
 
-	err := config.InitConfig("", io.Discard)
+	err := config.InitConfig("")
 	require.NoError(t, err, "Could not init config")
 
 	err = os.MkdirAll(path.Join(config.GetHomeDir(), "tests"), 0755)

--- a/internal/web/test/server.go
+++ b/internal/web/test/server.go
@@ -226,7 +226,7 @@ func Setup(t *testing.T) *Server {
 	tmpDir := t.TempDir()
 	t.Setenv("OPENGIST_SKIP_GIT_HOOKS", "1")
 
-	err := config.InitConfig("", io.Discard)
+	err := config.InitConfig("")
 	require.NoError(t, err, "Could not init config")
 
 	config.C.LogLevel = "warn"
@@ -236,6 +236,7 @@ func Setup(t *testing.T) *Server {
 
 	config.SetupSecretKey()
 	config.InitLog()
+	config.FlushStartupLog()
 
 	context.ManifestEntries = map[string]context.Asset{
 		"embed.css":   {File: "assets/embed.css"},


### PR DESCRIPTION
I noticed there's some inconsistency about logging and I'm trying here to rationalize it a bit:

- setup the logger early on as soon as the configuration has been parsed/validated
- default log level is currently `warn` so I'd expect a silent webserver start, when developing I like to have a clear picture of what's been configured so I keep it at `info` and this is how it looks with the patch: 
  <img width="2068" height="524" alt="image" src="https://github.com/user-attachments/assets/fccb23af-b363-447c-968b-e6480fc4a241" />
- I wonder if the `starting / finished action` should be lowered to `debug`, not sure what's that about though so I left untouched