### PR TITLE
fix(oidc): scope includes training whitespace if groups not configured

### DIFF
--- a/internal/auth/oauth/openid.go
+++ b/internal/auth/oauth/openid.go
@@ -20,15 +20,17 @@ type OIDCProvider struct {
 }
 
 func (p *OIDCProvider) RegisterProvider() error {
+	scopes := []string{"openid", "email", "profile"}
+	if config.C.OIDCGroupClaimName != "" {
+		scopes = append(scopes, config.C.OIDCGroupClaimName)
+	}
+
 	oidcProvider, err := openidConnect.New(
 		config.C.OIDCClientKey,
 		config.C.OIDCSecret,
 		urlJoin(p.URL, "/oauth/openid-connect/callback"),
 		config.C.OIDCDiscoveryUrl,
-		"openid",
-		"email",
-		"profile",
-		config.C.OIDCGroupClaimName,
+		scopes...,
 	)
 
 	if err != nil {


### PR DESCRIPTION
Hey!

If no groups claim name is specified, the app currently sends `openid email profile ` as scope (notice the trailing whitespace). Some OAuth providers (e.g. TinyAuth) can't handle that and return an `invalid scopes` error.

According to the OIDC spec, all scopes have to be space-delimited (https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims), so probably TinyAuth tries to find a scope with the name `""` (empty string) and fails because it doesn't exist.

This PR fixes it by only sending the `OIDCGroupClaimName` if it's configured.

Cheers