### PR TITLE
fix(helm): bind strategy configuration to deployment

### DIFF
--- a/helm/opengist/templates/deployment.yaml
+++ b/helm/opengist/templates/deployment.yaml
@@ -43,6 +43,10 @@ spec:
       serviceAccountName: {{ include "opengist.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.strategy }}
+      strategy:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-config
           image: busybox:1.37

--- a/helm/opengist/templates/deployment.yaml
+++ b/helm/opengist/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
   selector:
     matchLabels:
       {{- include "opengist.selectorLabels" . | nindent 6 }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:
@@ -43,10 +47,6 @@ spec:
       serviceAccountName: {{ include "opengist.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- with .Values.strategy }}
-      strategy:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       initContainers:
         - name: init-config
           image: busybox:1.37


### PR DESCRIPTION
The strategy was [previously defined](https://github.com/thomiceli/opengist/blob/master/helm/opengist/values.yaml#L29-L34) but never used.