### PR TITLE
Delete orphaned upload files once an hour

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -65,6 +65,13 @@ api.enabled: true
 # Disable file uploads when creating or editing gists (either `true` or `false`). Default: false
 disable-file-upload: false
 
+# How long an uploaded file can sit in {opengist-home}/uploads/ before the background
+# sweep removes it. Applies to files left behind when a user starts creating a gist,
+# uploads a file, and never submits (e.g. closes the tab). Successful gists move the
+# file out of uploads/ and are unaffected. Go duration format (e.g. "1h", "24h", "30m").
+# Default: 1h
+upload-orphan-ttl: 1h
+
 # File permissions for Unix socket (octal format). Default: 0666
 unix-socket-permissions: 0666
 

--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -45,13 +45,13 @@ type action struct {
 }
 
 var registry = map[int]action{
-	SyncReposFromFS:    {run: syncReposFromFS},
-	SyncReposFromDB:    {run: syncReposFromDB},
-	GitGcRepos:         {run: gitGcRepos},
-	SyncGistPreviews:   {run: syncGistPreviews},
-	ResetHooks:         {run: resetHooks},
-	IndexGists:         {run: indexGists},
-	SyncGistLanguages:  {run: syncGistLanguages},
+	SyncReposFromFS:           {run: syncReposFromFS},
+	SyncReposFromDB:           {run: syncReposFromDB},
+	GitGcRepos:                {run: gitGcRepos},
+	SyncGistPreviews:          {run: syncGistPreviews},
+	ResetHooks:                {run: resetHooks},
+	IndexGists:                {run: indexGists},
+	SyncGistLanguages:         {run: syncGistLanguages},
 	DeleteExpiredGists:        {run: deleteExpiredGists, spec: "@every 12h"},
 	SyncSSHKeys:               {run: syncSSHKeys, spec: "@every 72h"},
 	DeleteOrphanedUploadFiles: {run: deleteOrphanedUploadFiles, spec: "@every 1h"},

--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -26,6 +26,7 @@ const (
 	SyncGistLanguages
 	DeleteExpiredGists
 	SyncSSHKeys
+	DeleteOrphanedUploadFiles
 
 	numActions // keep last — sizes the `running` array
 )
@@ -51,8 +52,9 @@ var registry = map[int]action{
 	ResetHooks:         {run: resetHooks},
 	IndexGists:         {run: indexGists},
 	SyncGistLanguages:  {run: syncGistLanguages},
-	DeleteExpiredGists: {run: deleteExpiredGists, spec: "@every 12h"},
-	SyncSSHKeys:        {run: syncSSHKeys, spec: "@every 72h"},
+	DeleteExpiredGists:        {run: deleteExpiredGists, spec: "@every 12h"},
+	SyncSSHKeys:               {run: syncSSHKeys, spec: "@every 72h"},
+	DeleteOrphanedUploadFiles: {run: deleteOrphanedUploadFiles, spec: "@every 1h"},
 }
 
 func IsRunning(actionType int) bool {
@@ -229,5 +231,45 @@ func deleteExpiredGists() {
 
 	if len(gists) > 0 {
 		log.Info().Msgf("Deleted %d expired gist(s)", len(gists))
+	}
+}
+
+// deleteOrphanedUploadFiles removes files from {opengist-home}/uploads/ that
+// have been sitting untouched longer than the configured TTL. Successful gist
+// creation renames the file out of this directory via os.Rename, so anything
+// still here past the TTL is an abandoned upload (tab closed, validation
+// failed after upload, etc.).
+func deleteOrphanedUploadFiles() {
+	uploadsDir := filepath.Join(config.GetHomeDir(), "uploads")
+	entries, err := os.ReadDir(uploadsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		log.Error().Err(err).Msg("Cannot read uploads directory")
+		return
+	}
+
+	cutoff := time.Now().Add(-config.C.UploadOrphanTTLDuration())
+	var deleted int
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			if err := os.Remove(filepath.Join(uploadsDir, e.Name())); err != nil {
+				log.Error().Err(err).Msgf("Cannot delete orphaned upload %s", e.Name())
+				continue
+			}
+			deleted++
+		}
+	}
+
+	if deleted > 0 {
+		log.Info().Msgf("Deleted %d orphaned upload file(s)", deleted)
 	}
 }

--- a/internal/actions/actions_test.go
+++ b/internal/actions/actions_test.go
@@ -17,7 +17,10 @@ func setupTestConfig(t *testing.T) string {
 		t.Fatal(err)
 	}
 	config.C.OpengistHome = tmp
-	config.C.UploadOrphanTTL = "1h"
+	// InitConfig already defaults UploadOrphanTTL to "1h" and parses it into
+	// the cached duration field. Mutating UploadOrphanTTL directly after init
+	// has no effect on UploadOrphanTTLDuration() — call InitConfig again with
+	// a custom config file if a different TTL is needed in a test.
 	return tmp
 }
 

--- a/internal/actions/actions_test.go
+++ b/internal/actions/actions_test.go
@@ -1,0 +1,58 @@
+package actions
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/thomiceli/opengist/internal/config"
+)
+
+func setupTestConfig(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	if err := config.InitConfig("", io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	config.C.OpengistHome = tmp
+	config.C.UploadOrphanTTL = "1h"
+	return tmp
+}
+
+func TestDeleteOrphanedUploadFiles(t *testing.T) {
+	tmp := setupTestConfig(t)
+
+	uploads := filepath.Join(tmp, "uploads")
+	if err := os.MkdirAll(uploads, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	old := filepath.Join(uploads, "old-uuid")
+	fresh := filepath.Join(uploads, "fresh-uuid")
+	for _, p := range []string{old, fresh} {
+		if err := os.WriteFile(p, []byte("data"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	twoHoursAgo := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(old, twoHoursAgo, twoHoursAgo); err != nil {
+		t.Fatal(err)
+	}
+
+	deleteOrphanedUploadFiles()
+
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		t.Errorf("expected old upload to be deleted, got err=%v", err)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Errorf("expected fresh upload to be kept, got err=%v", err)
+	}
+}
+
+func TestDeleteOrphanedUploadFiles_MissingDir(t *testing.T) {
+	setupTestConfig(t)
+	deleteOrphanedUploadFiles()
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,8 @@ type config struct {
 	DisableFileUpload bool   `yaml:"disable-file-upload" env:"OG_DISABLE_FILE_UPLOAD"`
 	UploadOrphanTTL   string `yaml:"upload-orphan-ttl" env:"OG_UPLOAD_ORPHAN_TTL"`
 
+	uploadOrphanTTLDuration time.Duration // parsed once in InitConfig; use UploadOrphanTTLDuration()
+
 	UnixSocketPermissions string `yaml:"unix-socket-permissions" env:"OG_UNIX_SOCKET_PERMISSIONS"`
 
 	SshGit                string `yaml:"ssh.git-enabled" env:"OG_SSH_GIT_ENABLED"` // builtin | host | disabled (true → builtin, false → disabled)
@@ -135,18 +137,23 @@ func (c *config) SshManagesAuthorizedKeys() bool {
 }
 
 // UploadOrphanTTLDuration returns the configured max age for files sitting in
-// {opengist-home}/uploads/ before the orphan sweep removes them. Falls back to
-// 1h if the configured value is empty or unparseable.
+// {opengist-home}/uploads/ before the orphan sweep removes them.
+// The value is parsed once at startup by InitConfig; see parseUploadOrphanTTL.
 func (c *config) UploadOrphanTTLDuration() time.Duration {
-	if c.UploadOrphanTTL == "" {
-		return time.Hour
-	}
-	d, err := time.ParseDuration(c.UploadOrphanTTL)
-	if err != nil || d <= 0 {
+	return c.uploadOrphanTTLDuration
+}
+
+// parseUploadOrphanTTL parses UploadOrphanTTL and caches it. Called once from
+// InitConfig so that a misconfigured value is logged exactly once at startup.
+func (c *config) parseUploadOrphanTTL() {
+	if c.UploadOrphanTTL != "" {
+		if d, err := time.ParseDuration(c.UploadOrphanTTL); err == nil && d > 0 {
+			c.uploadOrphanTTLDuration = d
+			return
+		}
 		log.Warn().Msgf("Invalid upload-orphan-ttl %q, using default 1h", c.UploadOrphanTTL)
-		return time.Hour
 	}
-	return d
+	c.uploadOrphanTTLDuration = time.Hour
 }
 
 func configWithDefaults() (*config, error) {
@@ -208,6 +215,8 @@ func InitConfig(configPath string, out io.Writer) error {
 	// as the legacy booleans (true → builtin, false → disabled). Collapse whatever
 	// was provided into a canonical mode.
 	c.SshGit = normalizeSshGitMode(c.SshGit)
+
+	c.parseUploadOrphanTTL()
 
 	if c.OpengistHome == "" {
 		homeDir, err := os.UserHomeDir()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,7 +65,8 @@ type config struct {
 
 	ApiEnabled bool `yaml:"api.enabled" env:"OG_API_ENABLED"`
 
-	DisableFileUpload bool `yaml:"disable-file-upload" env:"OG_DISABLE_FILE_UPLOAD"`
+	DisableFileUpload bool   `yaml:"disable-file-upload" env:"OG_DISABLE_FILE_UPLOAD"`
+	UploadOrphanTTL   string `yaml:"upload-orphan-ttl" env:"OG_UPLOAD_ORPHAN_TTL"`
 
 	UnixSocketPermissions string `yaml:"unix-socket-permissions" env:"OG_UNIX_SOCKET_PERMISSIONS"`
 
@@ -133,6 +134,21 @@ func (c *config) SshManagesAuthorizedKeys() bool {
 	return c.SshGit == SshServerHost && c.SshAuthorizedKeysFile != ""
 }
 
+// UploadOrphanTTLDuration returns the configured max age for files sitting in
+// {opengist-home}/uploads/ before the orphan sweep removes them. Falls back to
+// 1h if the configured value is empty or unparseable.
+func (c *config) UploadOrphanTTLDuration() time.Duration {
+	if c.UploadOrphanTTL == "" {
+		return time.Hour
+	}
+	d, err := time.ParseDuration(c.UploadOrphanTTL)
+	if err != nil || d <= 0 {
+		log.Warn().Msgf("Invalid upload-orphan-ttl %q, using default 1h", c.UploadOrphanTTL)
+		return time.Hour
+	}
+	return d
+}
+
 func configWithDefaults() (*config, error) {
 	c := &config{}
 
@@ -152,6 +168,8 @@ func configWithDefaults() (*config, error) {
 	c.HttpGit = true
 
 	c.ApiEnabled = true
+
+	c.UploadOrphanTTL = "1h"
 
 	c.UnixSocketPermissions = "0666"
 

--- a/internal/i18n/locales/en-US.yml
+++ b/internal/i18n/locales/en-US.yml
@@ -360,6 +360,7 @@ admin.actions.index-gists: Rebuild search index
 admin.actions.sync-gist-languages: Synchronize all gists languages
 admin.actions.delete-expired-gists: Delete expired gists
 admin.actions.sync-ssh-keys: Regenerate the authorized_keys file
+admin.actions.delete-orphaned-uploads: Delete orphaned upload files
 admin.id: ID
 admin.user: User
 admin.delete: Delete

--- a/internal/i18n/locales/ko-KR.yml
+++ b/internal/i18n/locales/ko-KR.yml
@@ -325,6 +325,7 @@ admin.actions.index-gists: 검색 인덱스 재구성
 admin.actions.sync-gist-languages: 모든 gist 언어 동기화
 admin.actions.delete-expired-gists: 만료된 gist 삭제
 admin.actions.sync-ssh-keys: authorized_keys 파일 재생성
+admin.actions.delete-orphaned-uploads: 고아 업로드 파일 삭제
 admin.id: ID
 admin.user: 사용자
 admin.delete: 삭제

--- a/internal/web/handlers/admin/actions.go
+++ b/internal/web/handlers/admin/actions.go
@@ -31,6 +31,7 @@ var adminActions = []struct {
 	{actions.SyncGistLanguages, "sync-languages", "admin.actions.sync-gist-languages"},
 	{actions.DeleteExpiredGists, "delete-expired-gists", "admin.actions.delete-expired-gists"},
 	{actions.SyncSSHKeys, "sync-ssh-keys", "admin.actions.sync-ssh-keys"},
+	{actions.DeleteOrphanedUploadFiles, "delete-orphaned-uploads", "admin.actions.delete-orphaned-uploads"},
 }
 
 func AdminActions(ctx *context.Context) error {
@@ -103,6 +104,10 @@ func AdminDeleteExpiredGists(ctx *context.Context) error {
 
 func AdminSyncSSHKeys(ctx *context.Context) error {
 	return runAdminAction(ctx, actions.SyncSSHKeys, "flash.admin.sync-ssh-keys")
+}
+
+func AdminDeleteOrphanedUploads(ctx *context.Context) error {
+	return runAdminAction(ctx, actions.DeleteOrphanedUploadFiles, "flash.admin.delete-orphaned-uploads")
 }
 
 func runAdminAction(ctx *context.Context, actionType int, legacyFlashKey string) error {

--- a/internal/web/server/router.go
+++ b/internal/web/server/router.go
@@ -108,6 +108,7 @@ func (s *Server) registerRoutes() {
 			sB.POST("/sync-languages", admin.AdminSyncGistLanguages)
 			sB.POST("/delete-expired-gists", admin.AdminDeleteExpiredGists)
 			sB.POST("/sync-ssh-keys", admin.AdminSyncSSHKeys)
+			sB.POST("/delete-orphaned-uploads", admin.AdminDeleteOrphanedUploads)
 			sB.GET("/configuration", admin.AdminConfig)
 			sB.PUT("/set-config", admin.AdminSetConfig)
 		}


### PR DESCRIPTION
https://github.com/thomiceli/opengist/issues/785

Adds a background sweep that deletes orphaned upload files, files left in `{opengist-home}/uploads/` when a user starts creating a gist, uploads a file, but never submits (e.g. closes the tab).  The sweep runs every hour and removes any file older than the configured TTL (default 1h).  An admin action is also exposed so it can be triggered manually.

Not sure about `flash.admin.delete-orphaned-uploads` i18n key like with flash.admin.* action keys that are also missing from the locale files. 