### PR TITLE
Add copy button to fenced code blocks in rendered markdown

### DIFF
--- a/internal/render/markdown.go
+++ b/internal/render/markdown.go
@@ -16,6 +16,45 @@ import (
 	"go.abhg.dev/goldmark/mermaid"
 )
 
+// copyCodeBlockButton is injected into every fenced code block rendered from
+// Markdown (README previews, gist descriptions, .md files, comments) so users
+// can copy just that block's contents, the same way the file-level copy
+// button in gist.html works.
+const copyCodeBlockButton = `<button type="button" class="copy-btn copy-code-btn" aria-label="Copy code" _="on click
+	call navigator.clipboard.writeText(the previous <pre/>'s textContent)
+	set @data-copied to 'true'
+	wait 1.2s
+	remove @data-copied from me"><svg class="icon-copy size-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><svg class="icon-check size-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></button>`
+
+// wrapCodeBlockWithCopyButton wraps every fenced code block that goldmark
+// renders with a container div and a copy button. When chroma successfully
+// highlighted the block, it already wrote its own <pre> internally, so this
+// only adds the wrapping div and the button around it; otherwise (no lexer
+// match, or highlighting disabled for the block) the usual <pre><code> tags
+// have to be written here too, since goldmark-highlighting skips its default
+// ones once a custom wrapper renderer is set.
+func wrapCodeBlockWithCopyButton(w util.BufWriter, ctx highlighting.CodeBlockContext, entering bool) {
+	if entering {
+		_, _ = w.WriteString(`<div class="code-block-wrapper">`)
+		if !ctx.Highlighted() {
+			_, _ = w.WriteString("<pre><code")
+			if language, ok := ctx.Language(); ok && language != nil {
+				_, _ = w.WriteString(` class="language-`)
+				_, _ = w.Write(language)
+				_, _ = w.WriteString(`"`)
+			}
+			_, _ = w.WriteString(">")
+		}
+		return
+	}
+
+	if !ctx.Highlighted() {
+		_, _ = w.WriteString("</code></pre>")
+	}
+	_, _ = w.WriteString(copyCodeBlockButton)
+	_, _ = w.WriteString("</div>\n")
+}
+
 func MarkdownGistPreview(gist *db.Gist) (RenderedGist, error) {
 	var buf bytes.Buffer
 	err := newMarkdown().Convert([]byte(gist.Preview), &buf)
@@ -74,6 +113,7 @@ func newMarkdown(extraExtensions ...goldmark.Extender) goldmark.Markdown {
 		highlighting.NewHighlighting(
 			highlighting.WithStyle("catppuccin-latte"),
 			highlighting.WithFormatOptions(html.WithClasses(true)),
+			highlighting.WithWrapperRenderer(wrapCodeBlockWithCopyButton),
 		),
 		emoji.Emoji,
 		&mermaid.Extender{},

--- a/public/css/globals.css
+++ b/public/css/globals.css
@@ -216,6 +216,40 @@ textarea.input {
     background-color: transparent !important;
 }
 
+/* Wraps every fenced code block rendered from Markdown (internal/render/markdown.go)
+   so its copy button can sit pinned to the top-right corner instead of pushing
+   the block's own layout around. Hidden until the block is hovered or focused,
+   same reveal pattern as GitHub's Markdown code block copy button. */
+.code-block-wrapper {
+    position: relative;
+}
+.code-block-wrapper pre {
+    margin: 0;
+}
+.code-block-wrapper .copy-code-btn {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border);
+    background-color: var(--card);
+    color: var(--muted-foreground);
+    opacity: 0;
+    transition: opacity 0.1s ease-in-out;
+}
+.code-block-wrapper:hover .copy-code-btn,
+.code-block-wrapper .copy-code-btn:focus-visible,
+.code-block-wrapper .copy-code-btn[data-copied] {
+    opacity: 1;
+}
+.code-block-wrapper .copy-code-btn:hover {
+    color: var(--foreground);
+}
+
 /* Toggled by the gist editor (editor.ts). */
 .hidden-important {
     display: none !important;


### PR DESCRIPTION
Markdown previews (READMEs, gist descriptions, .md files, comment previews) render fenced code blocks through goldmark + chroma, but there was no way to copy just the contents of one of those blocks short of selecting the text by hand. The file view already has this for the whole file, so this adds the same thing per code block.

Hooks a wrapper renderer into the existing highlighting extension in `newMarkdown()` that wraps every fenced block in a container div and appends a copy button after it, reusing the same copy-btn icon swap and hyperscript pattern already used by the file-level copy button. The button copies the pre element's text content directly, so line numbers or highlighting markup never end up in the clipboard.

Also adds the CSS for the wrapper and button placement, pinned to the top-right corner of each block and revealed on hover/focus.

- `internal/render/markdown.go`: wrap fenced code blocks with a copy button via a goldmark-highlighting wrapper renderer
- `public/css/globals.css`: style and position the new code block copy button