### PR TITLE
Fix invalid header check in git cat-file batch reader

### DIFF
--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -221,8 +221,8 @@ func CatFileBatch(user string, gist string, revision string, truncate bool) ([]*
 		}
 
 		parts := strings.Fields(header)
-		if len(parts) > 3 {
-			continue // Not a valid header, skip this entry
+		if len(parts) < 3 {
+			continue // Not a valid header (e.g. "<hash> missing"), skip this entry
 		}
 
 		size, err := strconv.ParseUint(parts[2], 10, 64)


### PR DESCRIPTION
The bounds check in CatFileBatch had the comparison backwards. A valid `git cat-file --batch` header line is `<hash> <type> <size>`, three fields. When git reports an object as missing it writes `<hash> missing` instead, only two fields, but the code only skipped headers with more than three fields, so a missing object fell through and the next line indexed parts[2] on a two-element slice, panicking with an index out of range.

Ran into this while testing an unrelated PR (#801) — the macOS/sqlite test leg hit exactly this panic in a background gist-indexing goroutine racing test teardown. Verified the fix locally against the git, db, and api/v1 packages with `OPENGIST_TEST_DB=sqlite go test`, all passing where the panic used to happen. Opening as a draft until CI confirms it clean here too.