### PR TITLE
Fix overlapping headers in narrow embeds

### DIFF
--- a/internal/web/handlers/gist/gist_test.go
+++ b/internal/web/handlers/gist/gist_test.go
@@ -226,6 +226,7 @@ func TestGistJson(t *testing.T) {
 		require.Contains(t, embed["js_auto"], identifier+".js?auto")
 		require.NotEmpty(t, embed["css"])
 		require.NotEmpty(t, embed["html"])
+		require.Contains(t, embed["html"], `class="flow-root border-b-1`)
 	})
 
 	t.Run("Unlisted", func(t *testing.T) {

--- a/templates/partials/gist_embed.html
+++ b/templates/partials/gist_embed.html
@@ -2,7 +2,7 @@
     <div class="html {{.dark}}{{ if .themeAuto }} theme-auto{{ end }}">
     {{ range $file := .files }}
         <div class="rounded-md border-1 border-gray-100 dark:border-gray-800 overflow-auto mb-4">
-            <div class="border-b-1 border-gray-100 dark:border-gray-700 text-xs p-2 pl-4 bg-gray-50 dark:bg-gray-800 text-gray-400">
+            <div class="flow-root border-b-1 border-gray-100 dark:border-gray-700 text-xs p-2 pl-4 bg-gray-50 dark:bg-gray-800 text-gray-400">
                 <a target="_blank" class="font-sans" href="{{ $.baseHttpUrl }}/{{ $.gist.User.Username }}/{{ $.gist.Identifier }}#file-{{ slug $file.Filename }}"><span class="font-bold text-gray-700 dark:text-gray-200">{{ $file.Filename }}</span> &middot; {{ $file.HumanSize }} &middot; {{ $file.Type }}</a>
                 <span class="float-right font-sans"><a target="_blank" href="{{ $.baseHttpUrl }}">Hosted via Opengist</a> &middot; <span class="text-gray-700 dark:text-gray-200 font-bold"><a target="_blank" href="{{ $.baseHttpUrl }}/{{ $.gist.User.Username }}/{{ $.gist.Identifier }}/raw/HEAD/{{$file.Filename}}">view raw</a></span>{{ if $file.MimeType.IsText }} &middot; <span class="text-gray-700 dark:text-gray-200 font-bold"><button class="copy-embed-btn cursor-pointer bg-transparent border-0 p-0">copy</button></span>{{ end }}</span>
             </div>


### PR DESCRIPTION
## Problem

On narrow embeds, the floated action links can wrap without increasing the header height, covering the first code rows.

## Fix

Contain the float with Tailwind's `flow-root` utility and assert the rendered embed includes it.

## User impact

Embedded gists remain readable on narrow screens when the action links wrap.

## Verification

- Frontend build completed with `vite -c public/vite.config.js build` (existing CSS optimizer warnings only).
- Added the rendered-embed assertion in `TestGistJson`.
- `go test ./internal/web/handlers/gist -run '^TestGistJson/Public$'` did not complete in this Windows environment; no failure was reported before the timeout.

Fixes #791