### PR TITLE
Return 413 for oversized gist forms

### DIFF
--- a/internal/web/handlers/gist/create.go
+++ b/internal/web/handlers/gist/create.go
@@ -1,6 +1,7 @@
 package gist
 
 import (
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -25,6 +26,9 @@ func Create(ctx *context.Context) error {
 
 func ProcessCreate(ctx *context.Context) error {
 	isCreate := ctx.Request().URL.Path == "/"
+	if ctx.Request().ContentLength > 10<<20 {
+		return ctx.ErrorRes(http.StatusRequestEntityTooLarge, "Gist form exceeds the 10 MB request limit", nil)
+	}
 
 	dto := new(db.GistDTO)
 	var gist *db.Gist

--- a/internal/web/handlers/gist/create_test.go
+++ b/internal/web/handlers/gist/create_test.go
@@ -1,6 +1,7 @@
 package gist_test
 
 import (
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -71,6 +72,17 @@ func TestGistCreation(t *testing.T) {
 		count, err := db.CountAll(db.Gist{})
 		require.NoError(t, err)
 		require.Equal(t, int64(0), count)
+	})
+
+	t.Run("ContentTooLarge", func(t *testing.T) {
+		s.Login(t, "thomas")
+		resp := s.Request(t, "POST", "/", url.Values{
+			"name":    {"large.txt"},
+			"content": {strings.Repeat("a", 10<<20)},
+		}, http.StatusRequestEntityTooLarge)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(body), "Gist form exceeds the 10 MB request limit")
 	})
 
 	tests := []struct {


### PR DESCRIPTION
## Problem / Context

URL-encoded gist forms over Go's 10 MB parsing limit currently fall through with an empty file list, so users see the misleading 400 error “Not enough Files”.

Fixes https://github.com/thomiceli/opengist/issues/792

## Fix / Changes

- Return HTTP 413 when the create/edit gist form exceeds the existing 10 MB request limit.
- Show an explicit message naming that limit.
- Cover the status and rendered message in the existing gist creation suite.

## User impact

Oversized gist submissions now explain why the request failed instead of suggesting that the gist has no files.

## Verification

- go test ./internal/web/handlers/gist -run '^TestGistCreation$/ContentTooLarge$' -count=1 — passed
- go test ./internal/web/handlers/gist -count=1 — passed (87.990s)
- golangci-lint run --timeout=20m --disable=errcheck ./internal/web/handlers/gist/... — 0 issues
- go test ./... -p 1 — changed package and integration-heavy API packages passed; the Windows run exited non-zero on unrelated existing temp-file locking, symlink privilege, Git default-branch, and Git HTTP environment failures